### PR TITLE
Visual QA pass 1: compactness, purple contrast, hero integration, lib…

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 --duration-reveal:0.8s;--duration-hover:0.4s;
 /* === ARCHITECTURAL GRID === */
 --grid-line:rgba(255,255,255,0.025);
---section-pad:90px;
+--section-pad:72px;
 }
 html{scroll-behavior:smooth;overflow-x:hidden;max-width:100vw}
 body{font-family:var(--font);background:var(--black);color:var(--white);line-height:1.7;overflow-x:hidden;max-width:100vw;direction:rtl;-webkit-font-smoothing:antialiased;position:relative}
@@ -137,12 +137,12 @@ section::before{content:'';position:absolute;inset:0;pointer-events:none;z-index
 .glow-divider::after{content:'';position:absolute;top:-1px;left:50%;transform:translateX(-50%);width:40px;height:2px;background:linear-gradient(90deg,transparent,rgba(143,47,160,0.5),transparent);border-radius:2px;opacity:0.8}
 
 /* TYPOGRAPHY */
-.micro-copy{font-size:12px;font-weight:500;color:#b8bac6;letter-spacing:1.2px;text-transform:uppercase;margin-bottom:16px}
-h1{font-size:clamp(30px,5vw,56px);font-weight:800;line-height:1.12;margin-bottom:24px;letter-spacing:-0.8px}
-h2{font-size:clamp(26px,4vw,42px);font-weight:800;line-height:1.18;margin-bottom:24px;letter-spacing:-0.5px}
-h3{font-size:clamp(18px,2.5vw,24px);font-weight:700;line-height:1.32;margin-bottom:16px}
-.highlight{color:var(--core-light);text-shadow:0 0 20px rgba(143,47,160,0.3)}
-.sub-text{font-size:16px;color:var(--white-dim);line-height:1.85;max-width:680px}
+.micro-copy{font-size:12px;font-weight:500;color:#b8bac6;letter-spacing:1.2px;text-transform:uppercase;margin-bottom:14px}
+h1{font-size:clamp(28px,4.4vw,48px);font-weight:800;line-height:1.12;margin-bottom:20px;letter-spacing:-0.7px}
+h2{font-size:clamp(24px,3.4vw,36px);font-weight:800;line-height:1.18;margin-bottom:20px;letter-spacing:-0.4px}
+h3{font-size:clamp(17px,2.2vw,22px);font-weight:700;line-height:1.32;margin-bottom:14px}
+.highlight{color:var(--core-light);text-shadow:0 0 16px rgba(172,25,183,0.28)}
+.sub-text{font-size:15.5px;color:var(--white-dim);line-height:1.8;max-width:680px}
 
 /* CTA BUTTON — glass-metal hybrid */
 .cta-btn{display:inline-block;padding:17px 44px;background:linear-gradient(135deg,rgba(20,20,28,0.85),rgba(14,14,20,0.9));backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);color:var(--white);font-family:var(--font);font-size:16px;font-weight:700;border:1px solid rgba(255,255,255,0.15);border-radius:12px;cursor:pointer;transition:all 0.4s var(--ease-structural);box-shadow:0 12px 32px rgba(0,0,0,0.4),inset 0 1px 0 rgba(255,255,255,0.1);position:relative;overflow:visible;letter-spacing:0.3px}
@@ -189,45 +189,44 @@ section{transition:none;transform-origin:center center}
 .modal-form .cta-btn{width:100%;text-align:center}
 .modal-form .error-msg{color:#f44336;font-size:12px;margin-top:-8px;margin-bottom:8px;display:none}
 
-/* ===== HERO (Strategic War Room) ===== */
-.hero{min-height:100vh;display:flex;align-items:center;justify-content:center;padding-top:120px;padding-bottom:0;position:relative;overflow:visible;background:
+/* ===== HERO (Strategic War Room — integrated) ===== */
+.hero{min-height:auto;display:flex;align-items:center;justify-content:center;padding-top:104px;padding-bottom:48px;position:relative;overflow:visible;background:
 radial-gradient(ellipse 55% 42% at 50% 60%,rgba(120,55,140,0.08),transparent 60%)}
 .hero::before{display:none}
 .hero::after{content:'';position:absolute;inset:0;pointer-events:none;z-index:0;background:
 linear-gradient(180deg,rgba(0,0,0,0.55),transparent 20%,transparent 80%,rgba(0,0,0,0.6))}
-.hero-inner{display:flex;flex-direction:column;align-items:center;z-index:2;position:relative;max-width:var(--max-width);margin:0 auto;direction:rtl;text-align:center}
-.hero-content{z-index:2;position:relative;direction:rtl;text-align:center;max-width:800px;width:100%}
-.hero-figure{direction:rtl;margin-top:40px}
-.hero-content .micro-copy{margin-bottom:20px}
-.hero-cta-area{margin-top:36px;position:relative;z-index:3}
+.hero-inner{display:grid;grid-template-columns:1.2fr 0.8fr;align-items:center;gap:40px;z-index:2;position:relative;max-width:var(--max-width);margin:0 auto;direction:rtl}
+.hero-content{z-index:2;position:relative;direction:rtl;text-align:right;width:100%}
+.hero-figure{direction:rtl;margin:0;display:flex;align-items:center;justify-content:center}
+.hero-content .micro-copy{margin-bottom:14px}
+.hero-cta-area{margin-top:28px;position:relative;z-index:3}
 
-/* Hero headline: two-line style */
-.hero-headline{position:relative;z-index:3;margin-bottom:24px}
-.hero-headline .hero-line1{display:block;font-size:clamp(32px,5vw,58px);font-weight:800;color:var(--white);line-height:1.12;letter-spacing:-1px}
-.hero-headline .hero-line2{display:block;font-size:clamp(32px,5vw,58px);font-weight:800;line-height:1.12;letter-spacing:-1px;color:var(--core-light);text-shadow:0 0 24px rgba(120,55,140,0.10)}
-.hero-headline .hero-line3{display:block;font-size:clamp(32px,5vw,58px);font-weight:800;line-height:1.12;letter-spacing:-1px;color:var(--white)}
+/* Hero headline: three-line style (compact) */
+.hero-headline{position:relative;z-index:3;margin-bottom:20px}
+.hero-headline .hero-line1{display:block;font-size:clamp(26px,3.6vw,42px);font-weight:800;color:var(--white);line-height:1.14;letter-spacing:-0.6px}
+.hero-headline .hero-line2{display:block;font-size:clamp(26px,3.6vw,42px);font-weight:800;line-height:1.14;letter-spacing:-0.6px;color:var(--core-light);text-shadow:0 0 22px rgba(172,25,183,0.18)}
+.hero-headline .hero-line3{display:block;font-size:clamp(20px,2.6vw,28px);font-weight:700;line-height:1.4;letter-spacing:-0.3px;color:var(--white-dim);margin-top:10px}
 
 /* Hero figure with mask & glow */
 .hero-figure{position:relative;z-index:2}
-.hero-figure-glow{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:720px;height:720px;background:radial-gradient(ellipse 75% 65% at 50% 50%,rgba(130,50,155,0.32),rgba(120,55,140,0.14) 50%,transparent 80%);filter:blur(130px);z-index:0;pointer-events:none}
-.hero-figure img{position:relative;z-index:1;width:100%;min-width:420px;max-width:420px;display:block;margin:0 auto;-webkit-mask-image:linear-gradient(to bottom,#000 35%,rgba(0,0,0,0.5) 60%,rgba(0,0,0,0.15) 80%,transparent 100%);mask-image:linear-gradient(to bottom,#000 35%,rgba(0,0,0,0.5) 60%,rgba(0,0,0,0.15) 80%,transparent 100%);animation:heroFadeIn 1.2s var(--ease-structural) both}
+.hero-figure-glow{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:520px;height:560px;background:radial-gradient(ellipse 75% 65% at 50% 50%,rgba(172,25,183,0.34),rgba(154,0,165,0.14) 50%,transparent 80%);filter:blur(110px);z-index:0;pointer-events:none}
+.hero-figure img{position:relative;z-index:1;width:100%;min-width:auto;max-width:360px;display:block;margin:0 auto;-webkit-mask-image:linear-gradient(to bottom,#000 60%,rgba(0,0,0,0.6) 80%,rgba(0,0,0,0.2) 92%,transparent 100%);mask-image:linear-gradient(to bottom,#000 60%,rgba(0,0,0,0.6) 80%,rgba(0,0,0,0.2) 92%,transparent 100%);animation:heroFadeIn 1.2s var(--ease-structural) both}
 @keyframes heroFadeIn{from{opacity:0;transform:translateY(24px)}to{opacity:1;transform:translateY(0)}}
 
-.hero-focus{position:relative;display:block;max-width:720px;margin:18px auto 0;padding:32px 38px 34px;border-radius:28px;border:1px solid rgba(255,255,255,0.12);
-background:linear-gradient(160deg,rgba(16,16,24,0.7),rgba(12,12,18,0.65));box-shadow:0 50px 120px rgba(0,0,0,0.55),inset 0 1px 0 rgba(255,255,255,0.1),0 0 100px rgba(120,55,140,0.05);
-backdrop-filter:blur(28px);-webkit-backdrop-filter:blur(28px);isolation:isolate}
-.hero-focus::before{content:'';position:absolute;inset:-100px -60px -180px;pointer-events:none;z-index:0;opacity:0.6;filter:blur(50px);background:
-radial-gradient(500px 280px at 50% 85%,rgba(120,55,140,0.12),transparent 65%)}
-.hero-focus::after{content:'';position:absolute;inset:12px;pointer-events:none;z-index:2;border:1px solid rgba(255,255,255,0.1);border-radius:20px}
-.hero-focus .sub-text{position:relative;z-index:3;font-size:19px;line-height:1.75;max-width:100%;margin-left:auto;margin-right:auto}
-.hero .cta-btn{min-width:280px}
-.hero-figure{margin-bottom:-60px}
+.hero-focus{position:relative;display:block;max-width:100%;margin:14px 0 0;padding:22px 26px 24px;border-radius:20px;border:1px solid rgba(255,255,255,0.12);
+background:linear-gradient(160deg,rgba(16,16,24,0.7),rgba(12,12,18,0.65));box-shadow:0 32px 80px rgba(0,0,0,0.45),inset 0 1px 0 rgba(255,255,255,0.1),0 0 80px rgba(172,25,183,0.06);
+backdrop-filter:blur(24px);-webkit-backdrop-filter:blur(24px);isolation:isolate}
+.hero-focus::before{content:'';position:absolute;inset:-60px -40px -120px;pointer-events:none;z-index:0;opacity:0.5;filter:blur(40px);background:
+radial-gradient(380px 220px at 50% 85%,rgba(172,25,183,0.14),transparent 65%)}
+.hero-focus::after{content:'';position:absolute;inset:10px;pointer-events:none;z-index:2;border:1px solid rgba(255,255,255,0.08);border-radius:14px}
+.hero-focus .sub-text{position:relative;z-index:3;font-size:16px;line-height:1.7;max-width:100%;margin-left:auto;margin-right:auto}
+.hero .cta-btn{min-width:240px}
 
 /* ===== VSL ===== */
-.vsl-section{background:#050508;text-align:center;padding:100px 24px}
+.vsl-section{background:#050508;text-align:center;padding:var(--section-pad) 24px}
 .vsl-section h2{margin-bottom:16px}
 .vsl-wrapper{max-width:800px;margin:0 auto}
-.vsl-video{position:relative;width:100%;padding-bottom:56.25%;border-radius:20px;overflow:hidden;border:1.5px solid rgba(255,255,255,0.18);box-shadow:0 24px 60px rgba(0,0,0,0.55);margin:40px 0;background:#050508}
+.vsl-video{position:relative;width:100%;padding-bottom:56.25%;border-radius:18px;overflow:hidden;border:1.5px solid rgba(255,255,255,0.18);box-shadow:0 24px 56px rgba(0,0,0,0.55);margin:28px 0;background:#050508}
 .vsl-video iframe{position:absolute;top:0;left:0;width:100%;height:100%;border:none}
 .vsl-video--placeholder{padding-bottom:0}
 .vsl-placeholder-img{width:100%;display:block;border-radius:inherit}
@@ -242,67 +241,67 @@ radial-gradient(500px 280px at 50% 85%,rgba(120,55,140,0.12),transparent 65%)}
 .why-visual-img{width:100%;max-width:340px;height:auto;object-fit:contain;filter:drop-shadow(0 16px 32px rgba(0,0,0,0.5)) drop-shadow(0 0 60px rgba(120,55,140,0.1))}
 .why-content p{font-size:17px;color:var(--white-dim);line-height:1.9;margin-bottom:20px}
 .why-content p strong{color:var(--white);font-weight:600}
-.why-callout{padding:28px 32px;margin:30px auto;background:linear-gradient(145deg,rgba(18,18,26,0.6),rgba(14,14,20,0.5));backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);border:1px solid rgba(255,255,255,0.1);border-right:3px solid rgba(143,47,160,0.45);border-radius:12px;font-size:19px;color:var(--white);font-weight:500;max-width:760px;box-shadow:0 4px 20px rgba(0,0,0,0.2),0 0 40px rgba(143,47,160,0.04);text-align:right}
+.why-callout{padding:22px 26px;margin:24px auto;background:linear-gradient(145deg,rgba(18,18,26,0.6),rgba(14,14,20,0.5));backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);border:1px solid rgba(255,255,255,0.1);border-right:3px solid rgba(172,25,183,0.5);border-radius:12px;font-size:17px;color:var(--white);font-weight:500;max-width:760px;box-shadow:0 4px 20px rgba(0,0,0,0.2),0 0 36px rgba(172,25,183,0.05);text-align:right}
 .why-callout.reveal{transform:translateX(20px);opacity:0}
 .why-callout.reveal.visible{transform:translateX(0);opacity:1}
 
-/* ===== STEPS (VERTICAL TIMELINE) ===== */
+/* ===== STEPS (VERTICAL TIMELINE — compact) ===== */
 .steps-section{background:var(--black)}
-.steps-intro{text-align:center;margin-bottom:48px}
+.steps-intro{text-align:center;margin-bottom:32px}
 .steps-intro .sub-text{margin:0 auto}
-.steps-timeline{display:flex;flex-direction:column;gap:0;position:relative;max-width:800px;margin:0 auto}
+.steps-timeline{display:flex;flex-direction:column;gap:0;position:relative;max-width:760px;margin:0 auto}
 .steps-timeline::before{content:none}
-.steps-timeline-line{position:absolute;top:0;bottom:0;right:50%;transform:translateX(50%);width:2px;background:linear-gradient(180deg,rgba(185,33,204,0.5),rgba(143,47,160,0.35) 50%,rgba(185,33,204,0.5));z-index:0;transform-origin:top center;scale:1 0;box-shadow:0 0 8px rgba(185,33,204,0.25),0 0 24px rgba(143,47,160,0.12)}
-.step-row{display:grid;grid-template-columns:1fr 60px 1fr;align-items:center;gap:0;position:relative;z-index:1;padding:28px 0}
-.step-row-number{text-align:center;font-size:38px;font-weight:800;color:rgba(185,33,204,0.18);line-height:1;font-variant-numeric:tabular-nums;transition:color 0.6s ease}
-.step-row.activated .step-row-number{color:rgba(185,33,204,0.55)}
-.step-row-icon{display:flex;align-items:center;justify-content:center;width:52px;height:52px;margin:0 auto;border-radius:50%;background:rgba(143,47,160,0.08);border:1px solid rgba(143,47,160,0.18);box-shadow:0 0 0 rgba(120,55,140,0);transition:box-shadow 0.8s ease,border-color 0.8s ease}
-.step-row.activated .step-row-icon{box-shadow:0 0 18px rgba(185,33,204,0.2),0 0 40px rgba(143,47,160,0.1);border-color:rgba(185,33,204,0.35)}
-.step-row-content{padding:0 20px}
-.step-row-content h3{font-size:19px;margin-bottom:8px;color:var(--white);font-weight:700}
-.step-row-content p{font-size:15px;color:var(--white-dim);line-height:1.8}
+.steps-timeline-line{position:absolute;top:0;bottom:0;right:50%;transform:translateX(50%);width:2px;background:linear-gradient(180deg,rgba(172,25,183,0.55),rgba(154,0,165,0.35) 50%,rgba(172,25,183,0.55));z-index:0;transform-origin:top center;scale:1 0;box-shadow:0 0 8px rgba(172,25,183,0.25),0 0 24px rgba(154,0,165,0.12)}
+.step-row{display:grid;grid-template-columns:1fr 50px 1fr;align-items:center;gap:0;position:relative;z-index:1;padding:18px 0}
+.step-row-number{text-align:center;font-size:28px;font-weight:800;color:rgba(172,25,183,0.22);line-height:1;font-variant-numeric:tabular-nums;transition:color 0.6s ease}
+.step-row.activated .step-row-number{color:rgba(172,25,183,0.6)}
+.step-row-icon{display:flex;align-items:center;justify-content:center;width:42px;height:42px;margin:0 auto;border-radius:50%;background:rgba(172,25,183,0.08);border:1px solid rgba(172,25,183,0.2);box-shadow:0 0 0 rgba(154,0,165,0);transition:box-shadow 0.8s ease,border-color 0.8s ease}
+.step-row.activated .step-row-icon{box-shadow:0 0 16px rgba(172,25,183,0.22),0 0 36px rgba(154,0,165,0.1);border-color:rgba(172,25,183,0.4)}
+.step-row-content{padding:0 16px}
+.step-row-content h3{font-size:17px;margin-bottom:6px;color:var(--white);font-weight:700}
+.step-row-content p{font-size:14.5px;color:var(--white-dim);line-height:1.75}
 
 /* PROCESS */
 .process-section{background:var(--black)}
-.process-grid{display:grid;grid-template-columns:1fr 1.15fr;gap:28px;margin:40px 0}
-.process-card{border-radius:20px;padding:42px;position:relative}
+.process-grid{display:grid;grid-template-columns:1fr 1.15fr;gap:22px;margin:32px 0}
+.process-card{border-radius:18px;padding:28px 26px;position:relative}
 .process-card--group{opacity:1}
-.process-card--premium{border:1px solid rgba(143,47,160,0.25);box-shadow:0 8px 32px rgba(0,0,0,0.35),inset 0 1px 0 rgba(255,255,255,0.08);padding:48px 46px}
-.process-card--premium h3{font-size:24px;font-weight:800}
-.process-card--premium p{font-size:16px}
-.process-card h3{font-size:22px}
-.process-card p{font-size:15px;color:var(--white-dim);line-height:1.8}
-.process-card .card-badge{display:inline-flex;align-items:center;padding:5px 16px;background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.1);border-radius:20px;font-size:12px;font-weight:500;color:#c0c1cc;margin-bottom:16px;letter-spacing:0.3px}
-.process-highlight{background:linear-gradient(145deg,rgba(18,18,26,0.65),rgba(14,14,20,0.6));backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border:1px solid rgba(255,255,255,0.07);border-radius:16px;padding:28px;margin-top:16px;box-shadow:0 8px 32px rgba(0,0,0,0.25),inset 0 1px 0 rgba(255,255,255,0.06)}
-.process-highlight p{font-size:16px;color:var(--white-dim);line-height:1.8}
-.process-highlight .stat{font-size:28px;font-weight:800;color:#fff;letter-spacing:-0.5px}
+.process-card--premium{border:1px solid rgba(172,25,183,0.28);box-shadow:0 8px 32px rgba(0,0,0,0.35),inset 0 1px 0 rgba(255,255,255,0.08);padding:32px 28px}
+.process-card--premium h3{font-size:20px;font-weight:800}
+.process-card--premium p{font-size:15px}
+.process-card h3{font-size:19px}
+.process-card p{font-size:14.5px;color:var(--white-dim);line-height:1.75}
+.process-card .card-badge{display:inline-flex;align-items:center;padding:4px 14px;background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.1);border-radius:18px;font-size:12px;font-weight:500;color:#c0c1cc;margin-bottom:14px;letter-spacing:0.3px}
+.process-highlight{background:linear-gradient(145deg,rgba(18,18,26,0.65),rgba(14,14,20,0.6));backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border:1px solid rgba(255,255,255,0.07);border-radius:14px;padding:22px 24px;margin-top:14px;box-shadow:0 8px 32px rgba(0,0,0,0.25),inset 0 1px 0 rgba(255,255,255,0.06)}
+.process-highlight p{font-size:15px;color:var(--white-dim);line-height:1.75}
+.process-highlight .stat{font-size:24px;font-weight:800;color:#fff;letter-spacing:-0.5px}
 
 /* COMPARISON — SPLIT LAYOUT */
 .comparison-section{background:var(--black);position:relative;overflow:hidden}
 .comparison-section::before{display:none}
 .comparison-section::after{display:none}
-.comparison-section h2{color:var(--white);margin-bottom:24px}
-.comparison-section .highlight{color:var(--core)}
+.comparison-section h2{color:var(--white);margin-bottom:20px}
+.comparison-section .highlight{color:var(--core-light)}
 .compare-intro{text-align:center;font-size:17px;color:var(--white-dim);line-height:1.8;max-width:600px;margin:0 auto}
-.split-rows{margin-top:48px;max-width:900px;margin-left:auto;margin-right:auto}
-.split-row{display:grid;grid-template-columns:1fr 1fr;gap:48px;padding:32px 0;border-bottom:1px solid rgba(255,255,255,0.05);direction:rtl;align-items:start}
+.split-rows{margin-top:32px;max-width:900px;margin-left:auto;margin-right:auto}
+.split-row{display:grid;grid-template-columns:1fr 1fr;gap:36px;padding:22px 0;border-bottom:1px solid rgba(255,255,255,0.05);direction:rtl;align-items:start}
 .split-row:last-child{border-bottom:none}
 .split-left{text-align:right}
 .split-left h3{font-size:17px;font-weight:700;color:var(--white);margin-bottom:8px}
 .split-left p{font-size:15px;color:rgba(255,255,255,0.5);line-height:1.8}
-.split-right{text-align:right;background:rgba(143,47,160,0.04);border:1px solid rgba(143,47,160,0.08);border-right:2px solid rgba(143,47,160,0.25);border-radius:8px;padding:14px 16px}
-.split-right-label{display:block;font-size:12px;font-weight:600;color:rgba(195,140,220,0.6);letter-spacing:0.5px;margin-bottom:8px}
-.split-right p{font-size:16px;color:rgba(210,170,235,1);font-weight:700;line-height:1.8}
-.split-closing{text-align:center;max-width:600px;margin:64px auto 0}
-.split-closing-lead{font-size:16px;color:var(--white-dim);line-height:1.8;margin-bottom:16px}
-.split-closing-core{font-size:20px;font-weight:700;color:var(--white);line-height:1.6;margin-bottom:16px}
-.split-closing-link{font-size:17px;color:var(--core-light);font-weight:600}
+.split-right{text-align:right;background:rgba(172,25,183,0.05);border:1px solid rgba(172,25,183,0.1);border-right:2px solid rgba(172,25,183,0.32);border-radius:8px;padding:14px 16px}
+.split-right-label{display:block;font-size:12px;font-weight:600;color:rgba(208,150,232,0.7);letter-spacing:0.5px;margin-bottom:8px}
+.split-right p{font-size:15.5px;color:rgba(220,180,240,1);font-weight:700;line-height:1.75}
+.split-closing{text-align:center;max-width:600px;margin:44px auto 0}
+.split-closing-lead{font-size:15px;color:var(--white-dim);line-height:1.75;margin-bottom:14px}
+.split-closing-core{font-size:18px;font-weight:700;color:var(--white);line-height:1.55;margin-bottom:14px}
+.split-closing-link{font-size:16px;color:var(--core-light);font-weight:600}
 /* Why section heading override */
 .why-section h2{grid-column:1/-1;margin-bottom:32px}
 /* Final CTA inline replacements */
 .final-cta-body{max-width:780px}
 .final-cta-lead{font-size:18px;line-height:1.9;color:var(--white-dim)}
-.final-cta-quote{font-size:21px;font-weight:700;color:var(--white);line-height:1.7;border-right:3px solid rgba(143,47,160,0.55);padding-right:24px;text-shadow:0 0 20px rgba(143,47,160,0.1)}
+.final-cta-quote{font-size:20px;font-weight:700;color:var(--white);line-height:1.7;border-right:3px solid rgba(172,25,183,0.6);padding-right:22px;text-shadow:0 0 20px rgba(172,25,183,0.12)}
 .final-cta-bottom{max-width:600px}
 /* Tech item icon inline replacement */
 .tech-item-icon{height:18px;width:18px;object-fit:contain;display:inline-block;vertical-align:middle;margin-left:6px}
@@ -312,40 +311,40 @@ radial-gradient(500px 280px at 50% 85%,rgba(120,55,140,0.12),transparent 65%)}
 .svg-defs{position:absolute}
 
 /* DELIVERABLES — CLEAN SYSTEM */
-.deliverables-section{background:var(--black);color:var(--white);position:relative;overflow:hidden;padding-top:100px}
+.deliverables-section{background:var(--black);color:var(--white);position:relative;overflow:hidden;padding-top:var(--section-pad)}
 .deliverables-section>.container{position:relative}
 .deliverables-section .container>h2{text-align:center;max-width:900px;margin-left:auto;margin-right:auto;color:var(--white)}
-.deliverables-section .highlight{color:var(--core)}
+.deliverables-section .highlight{color:var(--core-light)}
 .deliverables-section .sub-text{color:var(--white-dim)}
-.deliverables-intro{text-align:center;margin:16px auto 0;max-width:600px}
-.deliverables-intro p{font-size:16px;color:var(--white-dim);line-height:1.7}
+.deliverables-intro{text-align:center;margin:14px auto 0;max-width:600px}
+.deliverables-intro p{font-size:15px;color:var(--white-dim);line-height:1.7}
 /* System layers */
 .system-layers{max-width:860px;margin:0 auto;position:relative}
-.system-layer{margin-bottom:48px;padding:0}
+.system-layer{margin-bottom:32px;padding:0}
 .system-layer:last-child{margin-bottom:0}
-.system-layer::after{content:'';display:block;margin:48px auto 0;height:1px;background:rgba(255,255,255,0.04)}
+.system-layer::after{content:'';display:block;margin:32px auto 0;height:1px;background:rgba(255,255,255,0.04)}
 .system-layer:last-child::after{display:none}
 .system-layer--foundations::after{max-width:100%}
 .system-layer--architecture::after{max-width:85%}
 .system-layer--engine::after{max-width:70%}
-.system-layer-header{display:flex;align-items:center;gap:16px;margin-bottom:16px}
+.system-layer-header{display:flex;align-items:center;gap:14px;margin-bottom:12px}
 .system-layer-line{flex:1;height:1px;background:rgba(255,255,255,0.08)}
-.system-layer--foundations .system-layer-line{background:rgba(130,100,160,0.08)}
-.system-layer--architecture .system-layer-line{background:rgba(160,120,190,0.08)}
-.system-layer--engine .system-layer-line{background:rgba(210,160,235,0.08)}
-.system-layer-name{font-size:15px;font-weight:700;white-space:nowrap}
-.system-layer--foundations .system-layer-name{color:rgba(150,115,180,0.85)}
-.system-layer--architecture .system-layer-name{color:rgba(175,135,205,0.9)}
-.system-layer--engine .system-layer-name{color:rgba(210,160,235,0.95)}
+.system-layer--foundations .system-layer-line{background:rgba(160,120,180,0.1)}
+.system-layer--architecture .system-layer-line{background:rgba(180,135,200,0.1)}
+.system-layer--engine .system-layer-line{background:rgba(220,165,235,0.1)}
+.system-layer-name{font-size:14px;font-weight:700;white-space:nowrap}
+.system-layer--foundations .system-layer-name{color:rgba(170,130,195,0.9)}
+.system-layer--architecture .system-layer-name{color:rgba(195,150,215,0.95)}
+.system-layer--engine .system-layer-name{color:rgba(220,165,235,1)}
 /* System items grid */
 .system-items{display:grid;gap:0;direction:rtl}
 .system-items--3{grid-template-columns:repeat(3,1fr)}
 .system-items--2{grid-template-columns:repeat(2,1fr)}
 /* System item — content unit, not a card */
-.system-item{padding:20px 16px;text-align:center}
-.system-item-icon{width:60px;height:60px;object-fit:contain;margin:0 auto 12px;display:block;opacity:0.9}
-.system-item h3{font-size:15px;font-weight:600;color:var(--white);margin-bottom:8px}
-.system-item p{font-size:13px;color:var(--white-dim);line-height:1.7;text-align:center}
+.system-item{padding:14px 12px;text-align:center}
+.system-item-icon{width:48px;height:48px;object-fit:contain;margin:0 auto 8px;display:block;opacity:0.9}
+.system-item h3{font-size:14px;font-weight:600;color:var(--white);margin-bottom:6px}
+.system-item p{font-size:12.5px;color:var(--white-dim);line-height:1.65;text-align:center}
 /* Bonus box — dark mode */
 .bonus-box{margin-top:24px;background:rgba(143,47,160,0.06);border:1px solid rgba(143,47,160,0.15);border-radius:16px;padding:24px 28px;display:flex;align-items:center;justify-content:center;gap:16px;max-width:700px;margin-left:auto;margin-right:auto}
 .bonus-badge{display:inline-flex;align-items:center;padding:6px 16px;background:rgba(255,255,255,0.05);border:1px solid rgba(143,47,160,0.25);border-radius:20px;font-size:13px;font-weight:600;white-space:nowrap;color:var(--core-light)}
@@ -354,21 +353,21 @@ radial-gradient(500px 280px at 50% 85%,rgba(120,55,140,0.12),transparent 65%)}
 
 /* TRANSFORMATION SECTION */
 .after-section{background:var(--black)}
-.transform-grid{display:flex;flex-direction:column;gap:0;max-width:700px;margin:40px auto 0}
-.transform-card{position:relative;padding:24px 0;border-radius:0;border:none;border-bottom:1px solid rgba(255,255,255,0.06);background:none;transition:none}
+.transform-grid{display:flex;flex-direction:column;gap:0;max-width:700px;margin:28px auto 0}
+.transform-card{position:relative;padding:18px 0;border-radius:0;border:none;border-bottom:1px solid rgba(255,255,255,0.06);background:none;transition:none}
 .transform-card:last-child{border-bottom:none}
 .transform-card::before{display:none}
 .transform-card:hover{border-color:rgba(255,255,255,0.06);box-shadow:none;transform:none}
 .transform-card--wide{grid-column:auto;text-align:inherit;max-width:none;margin:0;width:auto;border-color:transparent;box-shadow:none}
 .transform-card--wide::before{display:none}
-.transform-card strong{color:var(--white);font-weight:700;display:block;margin-bottom:6px;font-size:17px;line-height:1.6}
-.transform-card p{color:var(--white-dim);font-size:15px;line-height:1.7}
+.transform-card strong{color:var(--white);font-weight:700;display:block;margin-bottom:4px;font-size:16px;line-height:1.55}
+.transform-card p{color:var(--white-dim);font-size:14.5px;line-height:1.65}
 
 
 /* VIDEO TESTIMONIALS */
-.video-testimonials{background:radial-gradient(ellipse 70% 50% at 50% 40%,rgba(143,47,160,0.06),transparent 60%),var(--black-light)}
-.result-line{text-align:center;font-size:17px;color:var(--white);line-height:1.8;max-width:700px;margin:40px auto 0;font-weight:500}
-.videos-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-top:44px}
+.video-testimonials{background:radial-gradient(ellipse 70% 50% at 50% 40%,rgba(172,25,183,0.08),transparent 60%),var(--black-light)}
+.result-line{text-align:center;font-size:16px;color:var(--white);line-height:1.75;max-width:700px;margin:32px auto 0;font-weight:500}
+.videos-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:14px;margin-top:32px}
 .video-card{border-radius:16px;overflow:hidden;border:1px solid rgba(255,255,255,0.1);transition:border-color 0.4s var(--ease-structural),transform 0.4s var(--ease-structural),box-shadow 0.4s var(--ease-structural);background:var(--black-card);box-shadow:0 4px 20px rgba(0,0,0,0.3)}
 .video-card:hover{border-color:rgba(143,47,160,0.35);box-shadow:0 16px 48px rgba(0,0,0,0.5),0 0 60px rgba(143,47,160,0.08);transform:translateY(-5px)}
 .video-thumb{position:relative;cursor:pointer;aspect-ratio:9/16;overflow:hidden;background:var(--black-card)}
@@ -381,13 +380,13 @@ radial-gradient(500px 280px at 50% 85%,rgba(120,55,140,0.12),transparent 65%)}
 .play-small svg{fill:white;width:20px;height:20px;margin-right:-2px}
 
 /* STORY */
-.story-section{background:linear-gradient(180deg,var(--black) 0%,rgba(40,12,50,0.12) 30%,rgba(50,15,60,0.10) 50%,rgba(40,12,50,0.12) 70%,var(--black-light) 100%)}
-.story-grid{display:grid;grid-template-columns:380px 1fr;gap:56px;align-items:center}
+.story-section{background:linear-gradient(180deg,var(--black) 0%,rgba(50,15,60,0.14) 30%,rgba(60,18,72,0.12) 50%,rgba(50,15,60,0.14) 70%,var(--black-light) 100%)}
+.story-grid{display:grid;grid-template-columns:320px 1fr;gap:40px;align-items:center}
 .story-image{position:relative}
 .story-image img{width:100%;position:relative;z-index:2;-webkit-mask-image:linear-gradient(to bottom,#000 65%,transparent 96%);mask-image:linear-gradient(to bottom,#000 65%,transparent 96%);filter:drop-shadow(0 0 24px rgba(143,47,160,0.12))}
 .story-image-glow{position:absolute;top:40%;left:50%;transform:translate(-50%,-50%);width:380px;height:440px;background:radial-gradient(circle,rgba(143,47,160,0.18),rgba(120,40,150,0.06) 50%,transparent 70%);filter:blur(90px);z-index:1;pointer-events:none;opacity:0;transition:opacity 1.2s ease}
 .story-image-glow.glow-visible{opacity:1}
-.story-content p{font-size:16px;color:var(--white-dim);line-height:1.85;margin-bottom:22px;max-width:560px}
+.story-content p{font-size:15px;color:var(--white-dim);line-height:1.78;margin-bottom:16px;max-width:560px}
 
 /* (steps wiring removed — using vertical timeline) */
 
@@ -396,19 +395,19 @@ radial-gradient(500px 280px at 50% 85%,rgba(120,55,140,0.12),transparent 65%)}
 
 /* FILTER */
 .filter-section{background:var(--black-light)}
-.filter-grid{display:grid;grid-template-columns:1fr 1fr;gap:28px;margin-top:40px}
-.filter-card{border-radius:16px;padding:40px;position:relative}
+.filter-grid{display:grid;grid-template-columns:1fr 1fr;gap:22px;margin-top:28px}
+.filter-card{border-radius:14px;padding:28px 26px;position:relative}
 .filter-card::after{display:none}
-.filter-yes{border:1px solid rgba(143,47,160,0.2);background:linear-gradient(145deg,rgba(22,18,30,0.7),rgba(16,14,24,0.65));box-shadow:inset 0 1px 0 rgba(255,255,255,0.06);z-index:2}
-.filter-yes:hover{border-color:rgba(143,47,160,0.3)}
-.filter-yes h3{color:#fff;font-size:21px}
+.filter-yes{border:1px solid rgba(172,25,183,0.22);background:linear-gradient(145deg,rgba(22,18,30,0.7),rgba(16,14,24,0.65));box-shadow:inset 0 1px 0 rgba(255,255,255,0.06);z-index:2}
+.filter-yes:hover{border-color:rgba(172,25,183,0.32)}
+.filter-yes h3{color:#fff;font-size:19px}
 .filter-no{border:1px solid rgba(244,67,54,0.18);background:linear-gradient(145deg,rgba(58,10,10,0.25),rgba(10,10,14,0.5));opacity:0.75}
 .filter-no:hover{opacity:0.82}
 .filter-no h3{color:rgba(255,255,255,0.85)}
-.filter-card h3{font-size:20px;margin-bottom:20px}
-.filter-item{display:flex;gap:12px;margin-bottom:16px;font-size:15px;color:var(--white-dim);align-items:flex-start;line-height:1.7}
+.filter-card h3{font-size:18px;margin-bottom:14px}
+.filter-item{display:flex;gap:10px;margin-bottom:12px;font-size:14.5px;color:var(--white-dim);align-items:flex-start;line-height:1.65}
 .fi-icon{width:22px;height:22px;flex-shrink:0;display:flex;align-items:center;justify-content:center;border-radius:50%;font-size:13px;font-weight:700;line-height:1}
-.filter-yes .fi-icon{background:rgba(143,47,160,0.2);color:#c464d4;border:1px solid rgba(143,47,160,0.3)}
+.filter-yes .fi-icon{background:rgba(172,25,183,0.22);color:#d076e3;border:1px solid rgba(172,25,183,0.34)}
 .filter-no .fi-icon{background:rgba(244,67,54,0.1);color:rgba(244,67,54,0.7);border:1px solid rgba(244,67,54,0.2);font-weight:800}
 
 
@@ -421,7 +420,7 @@ radial-gradient(500px 280px at 50% 85%,rgba(120,55,140,0.12),transparent 65%)}
 .testimonial-wall h2{color:var(--white);text-align:center}
 .testimonial-wall .highlight{color:var(--core-light)}
 /* Featured testimonials — 2 large */
-.testimonial-featured{display:grid;grid-template-columns:repeat(2,1fr);gap:24px;margin-bottom:40px;max-width:900px;margin-left:auto;margin-right:auto;align-items:start}
+.testimonial-featured{display:grid;grid-template-columns:repeat(2,1fr);gap:20px;margin-bottom:28px;margin-top:24px;max-width:900px;margin-left:auto;margin-right:auto;align-items:start}
 .testimonial-card{border-radius:14px;overflow:hidden;border:1px solid rgba(255,255,255,0.08);box-shadow:0 6px 24px rgba(0,0,0,0.3);background:rgba(18,18,26,0.7);transition:transform 0.4s ease,box-shadow 0.4s ease;padding:6px}
 .testimonial-card:hover{transform:translateY(-3px);box-shadow:0 12px 36px rgba(0,0,0,0.4)}
 .testimonial-card img{width:100%;display:block;border-radius:10px}
@@ -442,7 +441,7 @@ radial-gradient(500px 280px at 50% 85%,rgba(120,55,140,0.12),transparent 65%)}
 
 
 /* Expand button — black glass + rotating neon border */
-.testimonial-expand-wrap{text-align:center;margin-top:40px}
+.testimonial-expand-wrap{text-align:center;margin-top:28px}
 .testimonial-expand-btn{display:inline-flex;align-items:center;gap:8px;padding:14px 36px;border:1px solid rgba(255,255,255,0.08);border-radius:50px;background:rgba(0,0,0,0.5);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);color:var(--white);font-family:var(--font);font-size:15px;font-weight:600;cursor:pointer;position:relative;z-index:0;transition:transform 0.3s,box-shadow 0.3s;box-shadow:0 0 20px rgba(143,47,160,0.25)}
 .testimonial-expand-btn:hover{transform:translateY(-1px);box-shadow:0 0 28px rgba(143,47,160,0.3)}
 .testimonial-expand-btn .arrow{display:inline-block;transition:transform 0.4s ease;font-size:18px}
@@ -453,40 +452,40 @@ radial-gradient(500px 280px at 50% 85%,rgba(120,55,140,0.12),transparent 65%)}
 .testimonial-card.in-view{opacity:1;transform:translateY(0)}
 
 /* TECH */
-.tech-section{background:var(--black-light);padding:60px 24px}
-.tech-box{border-radius:18px;padding:40px 36px;max-width:700px;margin:0 auto;position:relative;background:linear-gradient(160deg,rgba(16,16,22,0.65),rgba(12,12,18,0.55));border:1px solid rgba(255,255,255,0.06);box-shadow:0 8px 40px rgba(0,0,0,0.25)}
+.tech-section{background:var(--black-light);padding:48px 24px}
+.tech-box{border-radius:16px;padding:28px 26px;max-width:700px;margin:0 auto;position:relative;background:linear-gradient(160deg,rgba(16,16,22,0.65),rgba(12,12,18,0.55));border:1px solid rgba(255,255,255,0.06);box-shadow:0 8px 32px rgba(0,0,0,0.25)}
 .tech-box::after{display:none}
-.tech-grid{display:flex;flex-direction:column;gap:20px}
-.tech-item{display:flex;align-items:center;gap:14px;font-size:16px;color:var(--white);line-height:1.7;padding:6px 0}
-.tech-icon{width:8px;height:8px;border-radius:50%;background:rgba(185,155,210,0.7);display:inline-block;box-shadow:0 0 0 4px rgba(143,47,160,0.08);flex-shrink:0}
+.tech-grid{display:flex;flex-direction:column;gap:14px}
+.tech-item{display:flex;align-items:center;gap:12px;font-size:15px;color:var(--white);line-height:1.65;padding:4px 0}
+.tech-icon{width:8px;height:8px;border-radius:50%;background:rgba(200,165,225,0.75);display:inline-block;box-shadow:0 0 0 4px rgba(172,25,183,0.08);flex-shrink:0}
 
 /* ===== FAQ (SPLIT) ===== */
 .faq-section{background:linear-gradient(180deg,var(--black) 0%,rgba(14,14,20,0.8) 50%,var(--black) 100%)}
 .faq-list{max-width:780px;margin:0 auto}
-.faq-group-title{font-size:14px;font-weight:700;color:rgba(185,155,210,0.7);letter-spacing:1.2px;text-transform:uppercase;margin:44px 0 20px;padding-bottom:12px;border-bottom:1px solid rgba(143,47,160,0.1)}
-.faq-item{border-radius:14px;margin-bottom:12px;padding:0 28px;position:relative;border:1px solid rgba(255,255,255,0.07);background:rgba(14,14,20,0.45);transition:border-color 0.4s var(--ease-structural),background 0.4s,box-shadow 0.4s}
+.faq-group-title{font-size:13px;font-weight:700;color:rgba(200,165,225,0.75);letter-spacing:1.2px;text-transform:uppercase;margin:32px 0 16px;padding-bottom:10px;border-bottom:1px solid rgba(172,25,183,0.14)}
+.faq-item{border-radius:12px;margin-bottom:10px;padding:0 22px;position:relative;border:1px solid rgba(255,255,255,0.07);background:rgba(14,14,20,0.45);transition:border-color 0.4s var(--ease-structural),background 0.4s,box-shadow 0.4s}
 .faq-item::before{display:none}
 .faq-item:hover{border-color:rgba(255,255,255,0.14);background:rgba(14,14,20,0.6)}
-.faq-item.open{border-color:rgba(143,47,160,0.2);border-right:3px solid rgba(143,47,160,0.5);background:rgba(16,14,22,0.7);box-shadow:0 8px 32px rgba(0,0,0,0.3),0 0 50px rgba(143,47,160,0.05)}
-.faq-q{width:100%;display:flex;justify-content:space-between;align-items:center;padding:22px 0;background:none;border:none;color:var(--white);font-family:var(--font);font-size:16px;font-weight:500;cursor:pointer;text-align:right;gap:16px;transition:color 0.3s,font-weight 0.3s}
+.faq-item.open{border-color:rgba(172,25,183,0.24);border-right:3px solid rgba(172,25,183,0.55);background:rgba(16,14,22,0.7);box-shadow:0 8px 28px rgba(0,0,0,0.3),0 0 40px rgba(172,25,183,0.06)}
+.faq-q{width:100%;display:flex;justify-content:space-between;align-items:center;padding:16px 0;background:none;border:none;color:var(--white);font-family:var(--font);font-size:15.5px;font-weight:500;cursor:pointer;text-align:right;gap:14px;transition:color 0.3s,font-weight 0.3s}
 .faq-q:hover{color:#e0e1e8}
 .faq-item.open .faq-q{color:#fff;font-weight:600}
-.faq-icon{font-size:18px;color:var(--core-light);transition:transform 0.35s var(--ease-structural),background 0.35s,box-shadow 0.35s;flex-shrink:0;width:32px;height:32px;display:flex;align-items:center;justify-content:center;border-radius:50%;background:rgba(143,47,160,0.08);border:1px solid rgba(143,47,160,0.15)}
-.faq-item.open .faq-icon{transform:rotate(45deg);background:rgba(143,47,160,0.18);border-color:rgba(143,47,160,0.3);box-shadow:0 0 12px rgba(143,47,160,0.12)}
+.faq-icon{font-size:17px;color:var(--core-light);transition:transform 0.35s var(--ease-structural),background 0.35s,box-shadow 0.35s;flex-shrink:0;width:28px;height:28px;display:flex;align-items:center;justify-content:center;border-radius:50%;background:rgba(172,25,183,0.1);border:1px solid rgba(172,25,183,0.18)}
+.faq-item.open .faq-icon{transform:rotate(45deg);background:rgba(172,25,183,0.22);border-color:rgba(172,25,183,0.36);box-shadow:0 0 12px rgba(172,25,183,0.14)}
 .faq-a{max-height:0;overflow:hidden;transition:max-height 0.4s ease,padding 0.4s ease,opacity 0.4s ease;opacity:0}
-.faq-item.open .faq-a{opacity:1;padding-bottom:24px}
-.faq-a p{font-size:15px;color:var(--white-dim);line-height:1.85;padding-right:2px}
+.faq-item.open .faq-a{opacity:1;padding-bottom:18px}
+.faq-a p{font-size:14.5px;color:var(--white-dim);line-height:1.8;padding-right:2px}
 
 /* FINAL CTA */
-.final-cta-section{padding:var(--section-pad) 24px;background:radial-gradient(ellipse 65% 50% at 50% 45%,rgba(143,47,160,0.14),transparent 60%),radial-gradient(ellipse 40% 30% at 50% 80%,rgba(143,47,160,0.06),transparent 50%),var(--black)}
-.final-cta-section h2{margin-bottom:24px}
-.final-cta-section p{font-size:17px;color:var(--white-dim);line-height:1.8}
+.final-cta-section{padding:var(--section-pad) 24px;background:radial-gradient(ellipse 65% 50% at 50% 45%,rgba(172,25,183,0.16),transparent 60%),radial-gradient(ellipse 40% 30% at 50% 80%,rgba(172,25,183,0.07),transparent 50%),var(--black)}
+.final-cta-section h2{margin-bottom:20px}
+.final-cta-section p{font-size:16px;color:var(--white-dim);line-height:1.75}
 
 /* FINAL FORM (bottom) */
-.final-form-separator{height:1px;max-width:280px;margin:56px auto;background:linear-gradient(90deg,transparent,rgba(143,47,160,0.3),transparent)}
-.final-form{max-width:460px;margin:0 auto;position:relative;background:rgba(16,16,22,0.88);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);border:1px solid rgba(255,255,255,0.1);border-radius:22px;padding:40px 36px;box-shadow:0 28px 72px rgba(0,0,0,0.5),0 0 100px rgba(143,47,160,0.07)}
-.final-form::before{content:'';position:absolute;top:-1px;left:10%;right:10%;height:1px;background:linear-gradient(90deg,transparent,rgba(143,47,160,0.5),transparent);pointer-events:none}
-.final-form .cta-btn{background:linear-gradient(135deg,#70267f,#9a3bab)!important;border-color:rgba(185,33,204,0.35)!important;color:#fff}
+.final-form-separator{height:1px;max-width:280px;margin:40px auto;background:linear-gradient(90deg,transparent,rgba(172,25,183,0.34),transparent)}
+.final-form{max-width:460px;margin:0 auto;position:relative;background:rgba(16,16,22,0.88);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);border:1px solid rgba(255,255,255,0.1);border-radius:20px;padding:30px 28px;box-shadow:0 24px 60px rgba(0,0,0,0.45),0 0 80px rgba(172,25,183,0.08)}
+.final-form::before{content:'';position:absolute;top:-1px;left:10%;right:10%;height:1px;background:linear-gradient(90deg,transparent,rgba(172,25,183,0.55),transparent);pointer-events:none}
+.final-form .cta-btn{background:linear-gradient(135deg,#7a2c8a,#AC19B7)!important;border-color:rgba(172,25,183,0.4)!important;color:#fff}
 .final-form input,.final-form select{width:100%;padding:16px 20px;margin-bottom:14px;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1);border-radius:12px;color:var(--white);font-family:var(--font);font-size:15px;outline:none;transition:border-color 0.3s,box-shadow 0.3s;direction:rtl}
 .final-form input::placeholder{color:rgba(255,255,255,0.3)}
 .final-form input:focus,.final-form select:focus{border-color:var(--purple-main);box-shadow:0 0 0 3px rgba(143,47,160,0.12)}
@@ -533,10 +532,10 @@ radial-gradient(500px 280px at 50% 85%,rgba(120,55,140,0.12),transparent 65%)}
 .mt-8{margin-top:8px}
 .mt-16{margin-top:16px}
 .mt-32{margin-top:32px}
-.mt-48{margin-top:48px}
+.mt-48{margin-top:32px}
 .mb-12{margin-bottom:12px}
-.mb-24{margin-bottom:24px}
-.mb-48{margin-bottom:48px}
+.mb-24{margin-bottom:20px}
+.mb-48{margin-bottom:32px}
 .mx-auto{margin-left:auto;margin-right:auto}
 .mx-auto-32{margin:0 auto 32px}
 .sub-center{margin:0 auto;text-align:center}
@@ -548,7 +547,7 @@ radial-gradient(500px 280px at 50% 85%,rgba(120,55,140,0.12),transparent 65%)}
 .footer-social a{opacity:0.5;transition:opacity 0.3s}
 .footer-social a:hover{opacity:1}
 .footer-link{display:inline-flex;align-items:center}
-.section-desc{margin-bottom:24px;color:var(--white-dim);font-size:17px}
+.section-desc{margin-bottom:20px;color:var(--white-dim);font-size:16px}
 
 /* ===== CONSENT CHECKBOX ===== */
 .consent-checkbox{display:flex;align-items:flex-start;gap:10px;margin:12px 0 16px;cursor:pointer;font-size:13px;color:var(--white-dim);line-height:1.6}
@@ -621,14 +620,18 @@ section + .glow-divider{margin-top:0;margin-bottom:0}
 /* ===== RESPONSIVE — TABLET ONLY (481px – 768px) ===== */
 @media(min-width:481px) and (max-width:768px){
 .navbar-logo img{height:48px}
-/* Hero */
-.hero{padding-top:110px;min-height:auto;overflow:hidden}
-.hero-headline .hero-line1,.hero-headline .hero-line2,.hero-headline .hero-line3{font-size:clamp(28px,5.5vw,42px)}
-.hero-focus{padding:26px 22px 28px;max-width:100%;margin:18px auto 0;overflow:hidden}
-.hero-focus .sub-text{font-size:17px}
+/* Hero — collapse to single column */
+.hero{padding-top:96px;padding-bottom:32px;min-height:auto;overflow:hidden}
+.hero-inner{grid-template-columns:1fr;gap:24px;text-align:center}
+.hero-content{text-align:center}
+.hero-headline .hero-line1,.hero-headline .hero-line2{font-size:clamp(26px,5vw,38px)}
+.hero-headline .hero-line3{font-size:clamp(17px,3.2vw,22px)}
+.hero-focus{padding:20px 18px 22px;max-width:100%;margin:14px auto 0;overflow:hidden}
+.hero-focus .sub-text{font-size:15.5px}
 .hero .cta-btn{min-width:0;width:100%;max-width:380px}
-.hero-figure img{min-width:auto;max-width:260px}
-.hero-figure-glow{width:440px;height:480px;filter:blur(90px)}
+.hero-figure{order:-1}
+.hero-figure img{min-width:auto;max-width:240px}
+.hero-figure-glow{width:380px;height:420px;filter:blur(80px)}
 /* Timeline stays single column on tablet */
 .steps-timeline{max-width:100%}
 .process-grid{grid-template-columns:repeat(2,1fr)}
@@ -658,18 +661,21 @@ section + .glow-divider{margin-top:0;margin-bottom:0}
 .nav-links.nav-open{display:flex}
 .nav-links a{font-size:15px;padding:8px 0}
 .nav-links .nav-cta{width:100%;text-align:center;margin-top:8px}
-section{padding:80px 20px}
-.tech-section{padding:60px 20px}
-.hero{padding-top:102px;min-height:auto;overflow:hidden}
-.hero-figure img{min-width:auto;max-width:240px;-webkit-mask-image:linear-gradient(to bottom,#000 45%,rgba(0,0,0,0.5) 65%,rgba(0,0,0,0.15) 85%,transparent 100%);mask-image:linear-gradient(to bottom,#000 45%,rgba(0,0,0,0.5) 65%,rgba(0,0,0,0.15) 85%,transparent 100%)}
-.hero-figure-glow{width:min(360px,90vw);height:400px;filter:blur(90px);max-width:100vw}
-.hero-headline .hero-line1{font-size:clamp(26px,7vw,42px)}
-.hero-headline .hero-line2{font-size:clamp(26px,7vw,42px)}
-.hero-headline .hero-line3{font-size:clamp(26px,7vw,42px)}
-.hero-focus{padding:22px 18px 24px;border-radius:22px;max-width:100%;margin:18px auto 0;overflow:hidden}
-.hero-focus::before{inset:-60px -10px -100px;filter:blur(30px)}
-.hero-focus::after{inset:8px;border-radius:14px}
-.hero-focus .sub-text{font-size:17px;line-height:1.7}
+section{padding:60px 20px}
+.tech-section{padding:48px 20px}
+.hero{padding-top:90px;padding-bottom:24px;min-height:auto;overflow:hidden}
+.hero-inner{grid-template-columns:1fr;gap:20px;text-align:center}
+.hero-content{text-align:center}
+.hero-figure{order:-1}
+.hero-figure img{min-width:auto;max-width:220px;-webkit-mask-image:linear-gradient(to bottom,#000 55%,rgba(0,0,0,0.6) 78%,rgba(0,0,0,0.2) 92%,transparent 100%);mask-image:linear-gradient(to bottom,#000 55%,rgba(0,0,0,0.6) 78%,rgba(0,0,0,0.2) 92%,transparent 100%)}
+.hero-figure-glow{width:min(340px,88vw);height:380px;filter:blur(80px);max-width:100vw}
+.hero-headline .hero-line1{font-size:clamp(24px,6.5vw,36px)}
+.hero-headline .hero-line2{font-size:clamp(24px,6.5vw,36px)}
+.hero-headline .hero-line3{font-size:clamp(16px,4vw,20px);margin-top:8px}
+.hero-focus{padding:18px 16px 20px;border-radius:18px;max-width:100%;margin:14px auto 0;overflow:hidden}
+.hero-focus::before{inset:-40px -10px -80px;filter:blur(28px)}
+.hero-focus::after{inset:8px;border-radius:12px}
+.hero-focus .sub-text{font-size:15px;line-height:1.65}
 .hero .cta-btn{min-width:0;width:100%;max-width:360px}
 .sub-text{margin:0 auto}
 .steps-timeline{max-width:100%}
@@ -770,18 +776,18 @@ body{padding-bottom:70px}
 
 /* ===== RESPONSIVE — MOBILE ONLY (up to 480px) ===== */
 @media(max-width:480px){
-section{padding:60px 14px}
-.tech-section{padding:48px 14px}
-.hero{padding-top:82px}
-.hero-headline .hero-line1,.hero-headline .hero-line2,.hero-headline .hero-line3{font-size:clamp(24px,8vw,36px);letter-spacing:-0.5px}
-.hero-focus{padding:18px 14px 20px;border-radius:18px;margin:14px auto 0;overflow:hidden}
-.hero-focus::before{inset:-30px -5px -50px;filter:blur(25px)}
-.hero-focus .sub-text{font-size:15px;line-height:1.65}
-.hero-figure img{min-width:auto;max-width:220px;-webkit-mask-image:linear-gradient(to bottom,#000 50%,rgba(0,0,0,0.6) 75%,rgba(0,0,0,0.2) 90%,transparent 100%);mask-image:linear-gradient(to bottom,#000 50%,rgba(0,0,0,0.6) 75%,rgba(0,0,0,0.2) 90%,transparent 100%)}
-.hero-figure-glow{width:min(380px,92vw);height:420px;max-width:100vw;background:radial-gradient(ellipse 75% 65% at 50% 50%,rgba(130,50,155,0.36),rgba(120,55,140,0.16) 50%,transparent 80%)}
+section{padding:48px 14px}
+.tech-section{padding:40px 14px}
+.hero{padding-top:74px;padding-bottom:20px}
+.hero-headline .hero-line1,.hero-headline .hero-line2{font-size:clamp(22px,7.5vw,32px);letter-spacing:-0.4px}
+.hero-headline .hero-line3{font-size:clamp(15px,4.4vw,18px);margin-top:8px;letter-spacing:-0.2px}
+.hero-focus{padding:16px 14px 18px;border-radius:16px;margin:12px auto 0;overflow:hidden}
+.hero-focus::before{inset:-20px -5px -40px;filter:blur(22px)}
+.hero-focus .sub-text{font-size:14.5px;line-height:1.6}
+.hero-figure img{min-width:auto;max-width:200px;-webkit-mask-image:linear-gradient(to bottom,#000 60%,rgba(0,0,0,0.6) 80%,rgba(0,0,0,0.2) 92%,transparent 100%);mask-image:linear-gradient(to bottom,#000 60%,rgba(0,0,0,0.6) 80%,rgba(0,0,0,0.2) 92%,transparent 100%)}
+.hero-figure-glow{width:min(320px,86vw);height:360px;max-width:100vw;background:radial-gradient(ellipse 75% 65% at 50% 50%,rgba(172,25,183,0.36),rgba(154,0,165,0.16) 50%,transparent 80%)}
 .hero .cta-btn{width:100%;max-width:100%}
-.hero-cta-area{margin-top:24px}
-.hero-figure{margin-bottom:-50px}
+.hero-cta-area{margin-top:20px}
 /* Single column everywhere */
 .system-items .system-item{flex:0 0 86%;padding:16px 14px;grid-template-columns:42px 1fr;gap:0 12px}
 .system-items--2 .system-item{flex:0 0 90%}
@@ -1038,19 +1044,19 @@ h2{margin-bottom:20px}
 .consent-footer-link:hover{color:#c8c9d6}
 /* ===== SCROLL-FOCUS CLASS (replaces inline styles) ===== */
 .transform-card.scroll-focus{transform:none;border-color:rgba(255,255,255,0.06);box-shadow:none}
-/* ===== VISUAL ASSET PLACEHOLDERS (for new visual assets) ===== */
-.visual-placeholder{position:relative;width:100%;border-radius:18px;overflow:hidden;border:1px dashed rgba(172,25,183,0.32);background:
-  linear-gradient(140deg,rgba(20,7,23,0.7),rgba(7,8,12,0.85)),
-  radial-gradient(60% 50% at 50% 50%,rgba(154,0,165,0.10),transparent 70%);
-  display:flex;align-items:center;justify-content:center;text-align:center;padding:32px 24px;min-height:220px;color:var(--white-dim);font-size:13px;letter-spacing:0.6px;text-transform:uppercase;font-weight:600;
-  box-shadow:inset 0 1px 0 rgba(255,255,255,0.06),0 12px 36px rgba(0,0,0,0.35)}
-.visual-placeholder::before{content:'';position:absolute;inset:8px;border-radius:14px;border:1px solid rgba(255,255,255,0.05);pointer-events:none}
-.visual-placeholder .vp-label{position:relative;z-index:1;display:flex;flex-direction:column;gap:6px}
-.visual-placeholder .vp-tag{font-size:11px;color:var(--core-light);letter-spacing:1.4px}
-.visual-placeholder .vp-name{font-size:14px;color:var(--white);letter-spacing:0.6px}
-.visual-placeholder .vp-hint{font-size:11px;color:var(--white-mute,#a5a7b3);letter-spacing:0.4px;text-transform:none;font-weight:400;line-height:1.6;margin-top:8px;max-width:340px;margin-left:auto;margin-right:auto}
-.visual-placeholder--wide{min-height:300px}
-.visual-placeholder--tall{min-height:420px}
+/* ===== VISUAL ASSET PLACEHOLDERS (compact — temporary until final assets land) ===== */
+.visual-placeholder{position:relative;width:100%;border-radius:14px;overflow:hidden;border:1px dashed rgba(172,25,183,0.32);background:
+  linear-gradient(140deg,rgba(20,7,23,0.65),rgba(7,8,12,0.8)),
+  radial-gradient(60% 50% at 50% 50%,rgba(172,25,183,0.10),transparent 70%);
+  display:flex;align-items:center;justify-content:center;text-align:center;padding:18px 16px;min-height:130px;color:var(--white-dim);font-size:12px;letter-spacing:0.5px;text-transform:uppercase;font-weight:600;
+  box-shadow:inset 0 1px 0 rgba(255,255,255,0.06),0 8px 24px rgba(0,0,0,0.3)}
+.visual-placeholder::before{content:'';position:absolute;inset:6px;border-radius:10px;border:1px solid rgba(255,255,255,0.04);pointer-events:none}
+.visual-placeholder .vp-label{position:relative;z-index:1;display:flex;flex-direction:column;gap:4px}
+.visual-placeholder .vp-tag{font-size:10px;color:var(--core-light);letter-spacing:1.3px}
+.visual-placeholder .vp-name{font-size:13px;color:var(--white);letter-spacing:0.5px}
+.visual-placeholder .vp-hint{font-size:10.5px;color:var(--white-mute,#a5a7b3);letter-spacing:0.3px;text-transform:none;font-weight:400;line-height:1.55;margin-top:6px;max-width:320px;margin-left:auto;margin-right:auto}
+.visual-placeholder--wide{min-height:160px}
+.visual-placeholder--tall{min-height:220px}
 
 /* ===== AI SECTION (Strategic Brain Pulse) ===== */
 .ai-section{background:
@@ -1058,60 +1064,70 @@ h2{margin-bottom:20px}
   radial-gradient(ellipse 40% 30% at 50% 80%,rgba(80,13,95,0.18),transparent 60%),
   var(--black)}
 .ai-section .container{position:relative;z-index:2}
-.ai-section h2{text-align:center;margin-bottom:20px}
-.ai-section .ai-lead{text-align:center;max-width:720px;margin:0 auto 56px;font-size:17px;color:var(--white-dim);line-height:1.85}
-.ai-grid{display:grid;grid-template-columns:1.1fr 1fr;gap:48px;align-items:center;direction:rtl}
-.ai-pulse-visual{position:relative;min-height:380px}
+.ai-section h2{text-align:center;margin-bottom:16px}
+.ai-section .ai-lead{text-align:center;max-width:720px;margin:0 auto 36px;font-size:15.5px;color:var(--white-dim);line-height:1.75}
+.ai-grid{display:grid;grid-template-columns:1fr 1.1fr;gap:32px;align-items:center;direction:rtl}
+.ai-pulse-visual{position:relative;min-height:200px}
 .ai-pulse-visual .visual-placeholder{height:100%}
-.ai-points{display:flex;flex-direction:column;gap:24px}
-.ai-point{position:relative;padding:22px 26px 22px 22px;border-radius:14px;border:1px solid rgba(255,255,255,0.07);background:linear-gradient(150deg,rgba(20,7,23,0.7),rgba(17,16,20,0.6));backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);box-shadow:0 8px 28px rgba(0,0,0,0.3),inset 0 1px 0 rgba(255,255,255,0.05)}
-.ai-point::before{content:'';position:absolute;right:0;top:14px;bottom:14px;width:2px;background:linear-gradient(180deg,transparent,var(--core-light),transparent);border-radius:2px;opacity:0.55}
-.ai-point h3{font-size:18px;font-weight:700;color:var(--white);margin-bottom:8px;letter-spacing:-0.2px}
-.ai-point p{font-size:15px;color:var(--white-dim);line-height:1.75}
-.ai-callout{margin-top:48px;text-align:center;padding:24px 32px;max-width:720px;margin-left:auto;margin-right:auto;border-radius:16px;border:1px solid rgba(172,25,183,0.22);background:linear-gradient(145deg,rgba(80,13,95,0.18),rgba(20,7,23,0.7));font-size:17px;color:var(--white);font-weight:600;line-height:1.7;box-shadow:0 12px 40px rgba(0,0,0,0.35),inset 0 1px 0 rgba(255,255,255,0.05)}
+.ai-points{display:flex;flex-direction:column;gap:16px}
+.ai-point{position:relative;padding:18px 22px 18px 18px;border-radius:12px;border:1px solid rgba(255,255,255,0.07);background:linear-gradient(150deg,rgba(20,7,23,0.7),rgba(17,16,20,0.6));backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);box-shadow:0 6px 22px rgba(0,0,0,0.28),inset 0 1px 0 rgba(255,255,255,0.05)}
+.ai-point::before{content:'';position:absolute;right:0;top:12px;bottom:12px;width:2px;background:linear-gradient(180deg,transparent,var(--core-light),transparent);border-radius:2px;opacity:0.6}
+.ai-point h3{font-size:16px;font-weight:700;color:var(--white);margin-bottom:6px;letter-spacing:-0.2px}
+.ai-point p{font-size:14px;color:var(--white-dim);line-height:1.7}
+.ai-callout{margin-top:32px;text-align:center;padding:20px 26px;max-width:720px;margin-left:auto;margin-right:auto;border-radius:14px;border:1px solid rgba(172,25,183,0.26);background:linear-gradient(145deg,rgba(80,13,95,0.2),rgba(20,7,23,0.7));font-size:15.5px;color:var(--white);font-weight:600;line-height:1.65;box-shadow:0 10px 32px rgba(0,0,0,0.32),inset 0 1px 0 rgba(255,255,255,0.05)}
 
-/* ===== BOOKLET LIBRARY ===== */
+/* ===== BOOKLET LIBRARY (compact list under 3 groups, central mockup) ===== */
 .library-section{background:linear-gradient(180deg,var(--black) 0%,var(--black-light) 100%);position:relative;overflow:hidden}
-.library-section h2{text-align:center;margin-bottom:18px}
-.library-section .library-lead{text-align:center;max-width:640px;margin:0 auto 48px;font-size:16px;color:var(--white-dim);line-height:1.85}
-.library-shelf{display:grid;grid-template-columns:repeat(4,1fr);gap:18px;direction:rtl;max-width:1000px;margin:0 auto}
-.booklet{position:relative;border-radius:14px;overflow:hidden;border:1px solid rgba(255,255,255,0.07);background:linear-gradient(150deg,rgba(20,7,23,0.65),rgba(17,16,20,0.6));box-shadow:0 10px 28px rgba(0,0,0,0.35),inset 0 1px 0 rgba(255,255,255,0.05);transition:transform 0.4s var(--ease-structural),border-color 0.4s,box-shadow 0.4s;display:flex;flex-direction:column}
-.booklet:hover{transform:translateY(-3px);border-color:rgba(172,25,183,0.28);box-shadow:0 18px 44px rgba(0,0,0,0.45),0 0 60px rgba(154,0,165,0.08)}
-.booklet-cover{position:relative;aspect-ratio:3/4;background:
-  linear-gradient(160deg,rgba(80,13,95,0.45),rgba(20,7,23,0.7)),
-  radial-gradient(60% 50% at 50% 30%,rgba(172,25,183,0.18),transparent 70%);
-  display:flex;align-items:center;justify-content:center;border-bottom:1px solid rgba(255,255,255,0.05);padding:20px;text-align:center}
-.booklet-cover .booklet-num{position:absolute;top:10px;right:12px;font-size:11px;color:var(--core-light);letter-spacing:1.4px;font-weight:700}
-.booklet-cover .booklet-icon{width:44px;height:44px;border-radius:12px;background:linear-gradient(145deg,rgba(20,7,23,0.95),rgba(7,8,12,0.95));border:1px solid rgba(172,25,183,0.3);display:flex;align-items:center;justify-content:center;color:var(--core-light);font-weight:800;font-size:20px;box-shadow:0 6px 18px rgba(0,0,0,0.4)}
-.booklet-meta{padding:14px 16px 18px;text-align:right}
-.booklet-meta h3{font-size:14px;font-weight:700;color:var(--white);margin-bottom:6px;line-height:1.4}
-.booklet-meta p{font-size:12.5px;color:var(--white-dim);line-height:1.6}
-.library-note{margin-top:36px;text-align:center;font-size:14px;color:var(--white-dim);max-width:600px;margin-left:auto;margin-right:auto;line-height:1.7}
+.library-section h2{text-align:center;margin-bottom:14px}
+.library-section .library-lead{text-align:center;max-width:640px;margin:0 auto 28px;font-size:15.5px;color:var(--white-dim);line-height:1.8}
+.library-mockup{max-width:780px;margin:0 auto 36px}
+.library-mockup .visual-placeholder{min-height:170px}
+.library-group{max-width:880px;margin:0 auto 20px}
+.library-group:last-of-type{margin-bottom:0}
+.library-group-title{display:block;text-align:center;font-size:12px;letter-spacing:1.8px;color:var(--core-light);text-transform:uppercase;font-weight:700;margin:24px 0 14px;padding-bottom:10px;border-bottom:1px solid rgba(172,25,183,0.14)}
+.library-shelf{display:grid;grid-template-columns:repeat(2,1fr);gap:10px;direction:rtl;max-width:880px;margin:0 auto}
+.booklet{position:relative;border-radius:10px;overflow:hidden;border:1px solid rgba(255,255,255,0.07);background:linear-gradient(150deg,rgba(20,7,23,0.55),rgba(17,16,20,0.5));box-shadow:0 4px 14px rgba(0,0,0,0.25),inset 0 1px 0 rgba(255,255,255,0.04);transition:transform 0.3s var(--ease-structural),border-color 0.3s,box-shadow 0.3s;display:grid;grid-template-columns:44px 1fr;align-items:center;gap:0;padding:10px 14px}
+.booklet:hover{transform:translateY(-1px);border-color:rgba(172,25,183,0.3);box-shadow:0 6px 22px rgba(0,0,0,0.35),0 0 32px rgba(172,25,183,0.06)}
+.booklet-cover{position:relative;aspect-ratio:auto;background:
+  linear-gradient(145deg,rgba(80,13,95,0.55),rgba(20,7,23,0.85));
+  display:flex;align-items:center;justify-content:center;border-bottom:none;border:1px solid rgba(172,25,183,0.28);border-radius:8px;padding:0;width:36px;height:36px;flex-shrink:0}
+.booklet-cover .booklet-icon{width:auto;height:auto;border-radius:0;background:none;border:none;color:var(--core-light);font-weight:800;font-size:13px;letter-spacing:0.4px;box-shadow:none;display:block}
+.booklet-meta{padding:0 12px 0 0;text-align:right;min-width:0}
+.booklet-meta h3{font-size:13.5px;font-weight:700;color:var(--white);margin-bottom:2px;line-height:1.35}
+.booklet-meta p{font-size:12px;color:var(--white-dim);line-height:1.5}
+.library-note{margin-top:24px;text-align:center;font-size:13.5px;color:var(--white-dim);max-width:600px;margin-left:auto;margin-right:auto;line-height:1.7}
 
 /* ===== ROOT MEETING (Pgisha im hashoresh) ===== */
-.root-section .root-grid{display:grid;grid-template-columns:1fr 1fr;gap:48px;align-items:center;direction:rtl}
-.root-visual .visual-placeholder{min-height:340px}
+.root-section .root-grid{display:grid;grid-template-columns:1.2fr 0.8fr;gap:32px;align-items:center;direction:rtl}
+.root-visual .visual-placeholder{min-height:200px}
 
 /* ===== RESPONSIVE — NEW SECTIONS ===== */
 @media(max-width:768px){
-  .ai-grid{grid-template-columns:1fr;gap:28px}
-  .ai-pulse-visual{min-height:240px}
-  .ai-point{padding:18px 18px 18px 16px}
-  .library-shelf{grid-template-columns:repeat(2,1fr);gap:14px;max-width:480px}
+  .ai-grid{grid-template-columns:1fr;gap:24px}
+  .ai-pulse-visual{min-height:160px}
+  .ai-point{padding:16px 16px 16px 14px}
+  .library-shelf{grid-template-columns:1fr;gap:10px;max-width:520px}
   .booklet-meta h3{font-size:13.5px}
-  .root-section .root-grid{grid-template-columns:1fr;gap:24px}
+  .root-section .root-grid{grid-template-columns:1fr;gap:20px}
   .root-visual{order:-1}
-  .root-visual .visual-placeholder{min-height:220px}
-  .visual-placeholder{padding:24px 18px;min-height:180px}
-  .visual-placeholder--wide{min-height:220px}
-  .visual-placeholder--tall{min-height:300px}
-  .ai-callout{padding:20px 22px;font-size:15px}
+  .root-visual .visual-placeholder{min-height:140px}
+  .visual-placeholder{padding:16px 14px;min-height:120px}
+  .visual-placeholder--wide{min-height:140px}
+  .visual-placeholder--tall{min-height:170px}
+  .ai-callout{padding:18px 20px;font-size:14.5px}
 }
 @media(max-width:480px){
-  .library-shelf{grid-template-columns:1fr;max-width:320px}
-  .booklet-cover{aspect-ratio:16/9}
-  .ai-point h3{font-size:16px}
-  .ai-point p{font-size:14px}
+  .library-shelf{grid-template-columns:1fr;max-width:100%;gap:8px}
+  .booklet{padding:9px 12px;grid-template-columns:36px 1fr}
+  .booklet-cover{width:32px;height:32px}
+  .booklet-cover .booklet-icon{font-size:12px}
+  .booklet-meta h3{font-size:13px}
+  .booklet-meta p{font-size:11.5px;line-height:1.5}
+  .library-mockup{margin-bottom:24px}
+  .library-mockup .visual-placeholder{min-height:130px}
+  .library-group-title{font-size:11.5px;letter-spacing:1.4px}
+  .ai-point h3{font-size:15px}
+  .ai-point p{font-size:13.5px}
 }
 
 /* ===== PREFERS-REDUCED-MOTION ===== */
@@ -1489,7 +1505,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             <p>לא עוד שחקן בשוק — דמות עם עמדה ברורה שמבדילה אותך מההמולה.</p>
           </div>
         </div>
-        <p class="layer-result reveal" style="text-align:center;margin-top:24px;font-size:15px;color:var(--core-light);font-weight:600;letter-spacing:0.4px"><strong>התוצאה:</strong> אתה יודע בדיוק מי אתה, מה אתה מביא, ולמה דווקא ממך.</p>
+        <p class="layer-result reveal" style="text-align:center;margin-top:14px;font-size:14px;color:var(--core-light);font-weight:600;letter-spacing:0.4px"><strong>התוצאה:</strong> אתה יודע בדיוק מי אתה, מה אתה מביא, ולמה דווקא ממך.</p>
         <div class="carousel-dots"></div>
       </div>
 
@@ -1516,7 +1532,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             <p>מסביר איך הכסף זורם בעסק — מה ניתן בחינם, מה במחיר נמוך, ומה במחיר פרימיום.</p>
           </div>
         </div>
-        <p class="layer-result reveal" style="text-align:center;margin-top:24px;font-size:15px;color:var(--core-light);font-weight:600;letter-spacing:0.4px"><strong>התוצאה:</strong> יש לך מסלול ברור איך הלקוח פוגש אותך והופך לשגריר.</p>
+        <p class="layer-result reveal" style="text-align:center;margin-top:14px;font-size:14px;color:var(--core-light);font-weight:600;letter-spacing:0.4px"><strong>התוצאה:</strong> יש לך מסלול ברור איך הלקוח פוגש אותך והופך לשגריר.</p>
         <div class="carousel-dots"></div>
       </div>
 
@@ -1543,7 +1559,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             <p>שליטה מעשית ב־Claude Code, Codex וחיבור ל־GitHub — לא תיאוריה, יישום בפועל.</p>
           </div>
         </div>
-        <p class="layer-result reveal" style="text-align:center;margin-top:24px;font-size:15px;color:var(--core-light);font-weight:600;letter-spacing:0.4px"><strong>התוצאה:</strong> יש לך AI שמכיר את העסק שלך ולא כותב לך כמו כולם.</p>
+        <p class="layer-result reveal" style="text-align:center;margin-top:14px;font-size:14px;color:var(--core-light);font-weight:600;letter-spacing:0.4px"><strong>התוצאה:</strong> יש לך AI שמכיר את העסק שלך ולא כותב לך כמו כולם.</p>
         <div class="carousel-dots"></div>
       </div>
 
@@ -1570,7 +1586,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             <p>לא עוד "תבנית מקאנבה" — שפה שמייצגת אותך באופן עקבי בכל מקום.</p>
           </div>
         </div>
-        <p class="layer-result reveal" style="text-align:center;margin-top:24px;font-size:15px;color:var(--core-light);font-weight:600;letter-spacing:0.4px"><strong>התוצאה:</strong> הנוכחות הדיגיטלית עובדת בשבילך גם כשאתה לא מול המסך.</p>
+        <p class="layer-result reveal" style="text-align:center;margin-top:14px;font-size:14px;color:var(--core-light);font-weight:600;letter-spacing:0.4px"><strong>התוצאה:</strong> הנוכחות הדיגיטלית עובדת בשבילך גם כשאתה לא מול המסך.</p>
         <div class="carousel-dots"></div>
       </div>
 
@@ -1592,7 +1608,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             <p>שאלון סינון במערכת Fillout, וקופי לרצף מיילים שמחמם את הקהל למכירה קלה.</p>
           </div>
         </div>
-        <p class="layer-result reveal" style="text-align:center;margin-top:24px;font-size:15px;color:var(--core-light);font-weight:600;letter-spacing:0.4px"><strong>התוצאה:</strong> יש לך מסלול שמוביל אדם זר לנקודה שבה הוא מבין למה לדבר איתך.</p>
+        <p class="layer-result reveal" style="text-align:center;margin-top:14px;font-size:14px;color:var(--core-light);font-weight:600;letter-spacing:0.4px"><strong>התוצאה:</strong> יש לך מסלול שמוביל אדם זר לנקודה שבה הוא מבין למה לדבר איתך.</p>
         <div class="carousel-dots"></div>
       </div>
 
@@ -1609,38 +1625,54 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <section class="library-section" id="library">
   <div class="container">
     <p class="micro-copy reveal text-center">הספרייה האסטרטגית</p>
-    <h2 class="reveal">14 נכסים, <span class="highlight">ספרייה אחת שלמה.</span></h2>
+    <h2 class="reveal text-center">14 נכסים, <span class="highlight">ספרייה אחת שלמה.</span></h2>
     <p class="library-lead reveal reveal-delay-1">לא חוברת אחת ולא קובץ PDF, אלא ספרייה חיה של נכסים, חוברות ופרויקטים שמלווים אותך לאורך התהליך ונשארים איתך גם אחרי התהליך.</p>
 
-    <h3 class="library-group-title reveal" style="text-align:center;font-size:13px;letter-spacing:2px;color:var(--core-light);text-transform:uppercase;font-weight:700;margin-bottom:18px;margin-top:8px">תשתיות AI אישיות</h3>
-    <!-- TODO(visual): Booklet Library Covers. כל אחת מ־14 החוברות בעתיד תקבל עטיפה ויזואלית סופית לפי החוקה — להחליף את ה־cover הזמני (מספר על רקע פלטה). -->
-    <div class="library-shelf reveal reveal-delay-2">
-      <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">01</div></div><div class="booklet-meta"><h3>DNA שפה / פרופיל שפה</h3><p>פרופיל השפה האישי שלך, איך אתה מדבר, ובאיזו רמה.</p></div></article>
-      <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">02</div></div><div class="booklet-meta"><h3>סקילים בקלוד</h3><p>סקיל אישי שמכיר אותך, את העסק ואת השיטה שלך.</p></div></article>
-      <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">03</div></div><div class="booklet-meta"><h3>פרויקט קבצי האפיון</h3><p>פרויקט קלוד עם כל קבצי האפיון האסטרטגיים של העסק.</p></div></article>
-      <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">04</div></div><div class="booklet-meta"><h3>AI עסקי שמכיר אותך</h3><p>AI שיודע מי אתה, מי הלקוח, ומה הסיפור שלך.</p></div></article>
-      <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">05</div></div><div class="booklet-meta"><h3>חוקה ויזואלית למותג</h3><p>חוקה אחת שמייצרת קרוסלות, פוסטים, מצגות, גרפיקה ומודעות.</p></div></article>
-      <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">06</div></div><div class="booklet-meta"><h3>Claude Code, Codex, Manus + GitHub</h3><p>כלי הפיתוח של ה־AI, ואיך לעבוד איתם בפועל ולחבר ל־GitHub.</p></div></article>
+    <!-- TODO(visual): Library Mockup. דימוי מרכזי שמראה את הספרייה כמערכת אחת — להחליף את ה־placeholder לנכס סופי לפי החוקה. -->
+    <div class="library-mockup reveal reveal-delay-1">
+      <div class="visual-placeholder visual-placeholder--wide" role="img" aria-label="ספריית 14 הנכסים — מקום למוקאפ ויזואלי">
+        <span class="vp-label">
+          <span class="vp-tag">VISUAL · LIBRARY MOCKUP</span>
+          <span class="vp-name">ספריית 14 הנכסים</span>
+          <span class="vp-hint">דימוי שמציג את הספרייה כמערכת אחת — חוברות, סקילים, פרויקטים ונכסי AI.</span>
+        </span>
+      </div>
     </div>
 
-    <h3 class="library-group-title reveal" style="text-align:center;font-size:13px;letter-spacing:2px;color:var(--core-light);text-transform:uppercase;font-weight:700;margin-bottom:18px;margin-top:48px">חוברות עומק</h3>
-    <div class="library-shelf reveal reveal-delay-2">
-      <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">07</div></div><div class="booklet-meta"><h3>חוברת Instructions חכמים</h3><p>איך לבנות הוראות מערכת חכמות שעובדות בכל פלטפורמה.</p></div></article>
-      <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">08</div></div><div class="booklet-meta"><h3>חוברת Claude Cowork</h3><p>עבודה משותפת עם קלוד כמוח שני, לא ככלי.</p></div></article>
-      <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">09</div></div><div class="booklet-meta"><h3>חוברת Meta Prompt</h3><p>פרומפט שמייצר פרומפטים — מטא־רמה של AI מקצועי.</p></div></article>
-      <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">10</div></div><div class="booklet-meta"><h3>חוברת בניית סקילים</h3><p>מתי, איך ולמה לבנות סקיל בקלוד, צעד אחר צעד.</p></div></article>
-      <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">11</div></div><div class="booklet-meta"><h3>חוברת פרויקט בקלוד קוד</h3><p>איך מקימים, מנהלים ומריצים פרויקט בקלוד קוד.</p></div></article>
-      <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">12</div></div><div class="booklet-meta"><h3>חוברת מוח ויזואלי למותג</h3><p>השפה הוויזואלית שלך, ככה ש־AI ידע ליצור לך לפי החוקה.</p></div></article>
+    <div class="library-group reveal reveal-delay-2">
+      <h3 class="library-group-title">תשתיות AI אישיות</h3>
+      <div class="library-shelf">
+        <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">01</div></div><div class="booklet-meta"><h3>DNA שפה / פרופיל שפה</h3><p>פרופיל השפה האישי שלך, איך אתה מדבר, ובאיזו רמה.</p></div></article>
+        <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">02</div></div><div class="booklet-meta"><h3>סקילים בקלוד</h3><p>סקיל אישי שמכיר אותך, את העסק ואת השיטה שלך.</p></div></article>
+        <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">03</div></div><div class="booklet-meta"><h3>פרויקט קבצי האפיון</h3><p>פרויקט קלוד עם כל קבצי האפיון האסטרטגיים של העסק.</p></div></article>
+        <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">04</div></div><div class="booklet-meta"><h3>AI עסקי שמכיר אותך</h3><p>AI שיודע מי אתה, מי הלקוח, ומה הסיפור שלך.</p></div></article>
+        <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">05</div></div><div class="booklet-meta"><h3>חוקה ויזואלית למותג</h3><p>חוקה אחת שמייצרת קרוסלות, פוסטים, מצגות, גרפיקה ומודעות.</p></div></article>
+        <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">06</div></div><div class="booklet-meta"><h3>Claude Code, Codex, Manus + GitHub</h3><p>כלי הפיתוח של ה־AI, ואיך לעבוד איתם בפועל ולחבר ל־GitHub.</p></div></article>
+      </div>
     </div>
 
-    <h3 class="library-group-title reveal" style="text-align:center;font-size:13px;letter-spacing:2px;color:var(--core-light);text-transform:uppercase;font-weight:700;margin-bottom:18px;margin-top:48px">ספריות מומחים ומנטורים</h3>
-    <div class="library-shelf reveal reveal-delay-2" style="grid-template-columns:repeat(2,minmax(0,1fr));max-width:600px">
-      <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">13</div></div><div class="booklet-meta"><h3>ספריית מומחים</h3><p>מומחי AI לעסקים, שיווק, מכירות ומיתוג שמדמים יועצים אמיתיים.</p></div></article>
-      <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">14</div></div><div class="booklet-meta"><h3>מנטורים למכירות ושיחות מכירה</h3><p>מנטורים שמדמים מאסטרים בשיחות מכירה לאימון אישי.</p></div></article>
+    <div class="library-group reveal reveal-delay-2">
+      <h3 class="library-group-title">חוברות עומק וסקילים</h3>
+      <div class="library-shelf">
+        <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">07</div></div><div class="booklet-meta"><h3>חוברת Instructions חכמים</h3><p>איך לבנות הוראות מערכת חכמות שעובדות בכל פלטפורמה.</p></div></article>
+        <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">08</div></div><div class="booklet-meta"><h3>חוברת Claude Cowork</h3><p>עבודה משותפת עם קלוד כמוח שני, לא ככלי.</p></div></article>
+        <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">09</div></div><div class="booklet-meta"><h3>חוברת Meta Prompt</h3><p>פרומפט שמייצר פרומפטים — מטא־רמה של AI מקצועי.</p></div></article>
+        <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">10</div></div><div class="booklet-meta"><h3>חוברת בניית סקילים</h3><p>מתי, איך ולמה לבנות סקיל בקלוד, צעד אחר צעד.</p></div></article>
+        <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">11</div></div><div class="booklet-meta"><h3>חוברת פרויקט בקלוד קוד</h3><p>איך מקימים, מנהלים ומריצים פרויקט בקלוד קוד.</p></div></article>
+        <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">12</div></div><div class="booklet-meta"><h3>חוברת מוח ויזואלי למותג</h3><p>השפה הוויזואלית שלך, ככה ש־AI ידע ליצור לך לפי החוקה.</p></div></article>
+      </div>
+    </div>
+
+    <div class="library-group reveal reveal-delay-2">
+      <h3 class="library-group-title">ספריות מומחים ומנטורים</h3>
+      <div class="library-shelf">
+        <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">13</div></div><div class="booklet-meta"><h3>ספריית מומחים</h3><p>מומחי AI לעסקים, שיווק, מכירות ומיתוג שמדמים יועצים אמיתיים.</p></div></article>
+        <article class="booklet"><div class="booklet-cover"><div class="booklet-icon">14</div></div><div class="booklet-meta"><h3>מנטורים למכירות ושיחות מכירה</h3><p>מנטורים שמדמים מאסטרים בשיחות מכירה לאימון אישי.</p></div></article>
+      </div>
     </div>
 
     <p class="library-note reveal">הספרייה נועדה לתת לך בסיס עבודה שתוכל לחזור אליו, לשפר אותו ולהמשיך לבנות ממנו גם אחרי שהתהליך נגמר.</p>
-    <div class="text-center mt-48 reveal"><button class="cta-btn" onclick="openModal()">בוא נבדוק אם זה מתאים לך</button></div>
+    <div class="text-center mt-32 reveal"><button class="cta-btn" onclick="openModal()">בוא נבדוק אם זה מתאים לך</button></div>
   </div>
 </section>
 


### PR DESCRIPTION
…rary restructure

Design/rhythm pass only — no copy changes, no form changes, no GTM/Pixel/GA4/Consent/WEBHOOK/IDs/function changes.

Global compactness:
- --section-pad: 90px → 72px (~-20% on desktop)
- Mobile section padding: 80px → 60px; <480: 60px → 48px
- VSL/tech/AI use --section-pad instead of hardcoded
- h1: clamp(30,5vw,56) → clamp(28,4.4vw,48) (~-14%)
- h2: clamp(26,4vw,42) → clamp(24,3.4vw,36) (~-14%)
- h3: clamp(18,2.5vw,24) → clamp(17,2.2vw,22)
- mt-48/mb-48 utility: 48px → 32px
- Heading mb: 24px → 20px

Purple contrast (#AC19B7 promoted):
- .comparison-section .highlight: --core → --core-light
- .deliverables-section .highlight: --core → --core-light
- .split-right border/bg shifted from rgba(143,47,160) to rgba(172,25,183)
- .why-callout border: rgba(143,47,160,0.45) → rgba(172,25,183,0.5)
- .final-cta-quote, .final-form button gradient, FAQ icon, filter-yes accents all updated to use #AC19B7 family
- Highlight text-shadow: rgba(143,47,160,0.3) → rgba(172,25,183,0.28)

Hero (image integrated INSIDE hero, side by side on desktop):
- .hero-inner: column flex → grid 1.2fr/0.8fr (text+box+CTA on right, noback.png on left), both visible above the fold on desktop
- Hero text now right-aligned (RTL natural) on desktop
- Tablet/mobile: collapse to single column with image on top
- min-height:100vh → auto, padding-top: 120px → 104px
- Headline lines: clamp(32,5vw,58) → clamp(26,3.6vw,42) for line1/2
- line3 styled as supporting line (smaller, white-dim)
- hero-figure-glow: 720×720 → 520×560
- Hero image max-width: 420px → 360px on desktop
- hero-focus padding: 32px 38px 34px → 22px 26px 24px

Visual placeholders (-40 to -50%):
- min-height: 220px → 130px (-41%)
- --wide: 300px → 160px (-47%)
- --tall: 420px → 220px (-48%)
- root-visual: 340px → 200px
- Padding 32px 24px → 18px 16px
- Mobile: 180px → 120px

Three stages (timeline compact):
- Number font: 38px → 28px
- Icon: 52px → 42px
- Row padding: 28px 0 → 18px 0
- Grid: 1fr 60px 1fr → 1fr 50px 1fr

14 weeks (process):
- Card padding: 42px → 28px 26px
- Premium card: 48px 46px → 32px 28px
- h3 size: 22-24px → 19-20px
- 15,000 ש״ח / 8 מתוך 10 stat box content unchanged
- process-highlight padding: 28px → 22px 24px

Five layers (deliverables):
- system-layer margin-bottom: 48px → 32px
- system-item padding: 20px 16px → 14px 12px
- system-item-icon: 60px → 48px
- layer-result margin-top: 24px → 14px
- deliverables padding-top hardcoded 100px → var(--section-pad)

Booklet library — RESTRUCTURED:
- Added central library-mockup placeholder above all groups
- Wrapped each of 3 groups in .library-group container
- Replaced 14 large 3:4-aspect cards with compact horizontal rows (small numbered badge + title + brief desc, 2-col grid)
- All 14 items preserved verbatim
- Group titles centered with bottom border, no inline styles
- Booklet padding: full card → 10px 14px row
- Mobile: single column

Filter / Tech / FAQ:
- filter-card padding: 40px → 28px 26px
- filter-card h3: 21-20px → 19-18px
- tech-section padding: 60px → 48px
- tech-box padding: 40px 36px → 28px 26px
- faq-item padding: 0 28px → 0 22px
- faq-q padding: 22px 0 → 16px 0
- faq-icon: 32px → 28px

Story / Transform / VSL / Testimonials:
- story-grid: 380px 1fr → 320px 1fr, gap 56px → 40px
- transform-card padding: 24px 0 → 18px 0
- vsl-video margin: 40px → 28px
- testimonial-featured margin: 40px → 28px

Visual placeholders remain visible by design (Uriel needs to see where each future visual asset will land).
https://claude.ai/code/session_012PyS9bowC2QvF1UZqeF98G