### PR TITLE
Revert hero to centered column (text top, image below)

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,38 +189,37 @@ section{transition:none;transform-origin:center center}
 .modal-form .cta-btn{width:100%;text-align:center}
 .modal-form .error-msg{color:#f44336;font-size:12px;margin-top:-8px;margin-bottom:8px;display:none}
 
-/* ===== HERO (Strategic War Room — integrated) ===== */
-.hero{min-height:auto;display:flex;align-items:center;justify-content:center;padding-top:104px;padding-bottom:48px;position:relative;overflow:visible;background:
+/* ===== HERO (Strategic War Room — centered column) ===== */
+.hero{min-height:100vh;display:flex;align-items:center;justify-content:center;padding-top:110px;padding-bottom:0;text-align:center;position:relative;overflow:hidden;background:
 radial-gradient(ellipse 55% 42% at 50% 60%,rgba(120,55,140,0.08),transparent 60%)}
 .hero::before{display:none}
 .hero::after{content:'';position:absolute;inset:0;pointer-events:none;z-index:0;background:
 linear-gradient(180deg,rgba(0,0,0,0.55),transparent 20%,transparent 80%,rgba(0,0,0,0.6))}
-.hero-inner{display:grid;grid-template-columns:1.2fr 0.8fr;align-items:center;gap:40px;z-index:2;position:relative;max-width:var(--max-width);margin:0 auto;direction:rtl}
-.hero-content{z-index:2;position:relative;direction:rtl;text-align:right;width:100%}
-.hero-figure{direction:rtl;margin:0;display:flex;align-items:center;justify-content:center}
-.hero-content .micro-copy{margin-bottom:14px}
-.hero-cta-area{margin-top:28px;position:relative;z-index:3}
+.hero-inner{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:0;max-width:900px;margin:0 auto;text-align:center;direction:rtl;z-index:2;position:relative}
+.hero-content{z-index:2;position:relative;direction:rtl;text-align:center;width:100%;max-width:900px;margin:0 auto}
+.hero-content .micro-copy{margin-bottom:14px;text-align:center}
+.hero-cta-area{margin-top:28px;text-align:center;position:relative;z-index:3}
 
-/* Hero headline: three-line style (compact) */
-.hero-headline{position:relative;z-index:3;margin-bottom:20px}
+/* Hero headline: three-line style (centered, compact) */
+.hero-headline{position:relative;z-index:3;margin-bottom:20px;text-align:center;margin-left:auto;margin-right:auto}
 .hero-headline .hero-line1{display:block;font-size:clamp(26px,3.6vw,42px);font-weight:800;color:var(--white);line-height:1.14;letter-spacing:-0.6px}
 .hero-headline .hero-line2{display:block;font-size:clamp(26px,3.6vw,42px);font-weight:800;line-height:1.14;letter-spacing:-0.6px;color:var(--core-light);text-shadow:0 0 22px rgba(172,25,183,0.18)}
 .hero-headline .hero-line3{display:block;font-size:clamp(20px,2.6vw,28px);font-weight:700;line-height:1.4;letter-spacing:-0.3px;color:var(--white-dim);margin-top:10px}
 
-/* Hero figure with mask & glow */
-.hero-figure{position:relative;z-index:2}
-.hero-figure-glow{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:520px;height:560px;background:radial-gradient(ellipse 75% 65% at 50% 50%,rgba(172,25,183,0.34),rgba(154,0,165,0.14) 50%,transparent 80%);filter:blur(110px);z-index:0;pointer-events:none}
-.hero-figure img{position:relative;z-index:1;width:100%;min-width:auto;max-width:360px;display:block;margin:0 auto;-webkit-mask-image:linear-gradient(to bottom,#000 60%,rgba(0,0,0,0.6) 80%,rgba(0,0,0,0.2) 92%,transparent 100%);mask-image:linear-gradient(to bottom,#000 60%,rgba(0,0,0,0.6) 80%,rgba(0,0,0,0.2) 92%,transparent 100%);animation:heroFadeIn 1.2s var(--ease-structural) both}
+/* Hero figure (below text, centered) */
+.hero-figure{position:relative;z-index:2;direction:rtl;margin-top:64px;width:100%;display:flex;justify-content:center;align-items:center;order:2}
+.hero-figure-glow{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:720px;height:720px;background:radial-gradient(ellipse 75% 65% at 50% 50%,rgba(172,25,183,0.32),rgba(154,0,165,0.14) 50%,transparent 80%);filter:blur(130px);z-index:0;pointer-events:none}
+.hero-figure img{position:relative;z-index:1;width:100%;min-width:auto;max-width:420px;display:block;margin:0 auto;-webkit-mask-image:linear-gradient(to bottom,#000 35%,rgba(0,0,0,0.5) 60%,rgba(0,0,0,0.15) 80%,transparent 100%);mask-image:linear-gradient(to bottom,#000 35%,rgba(0,0,0,0.5) 60%,rgba(0,0,0,0.15) 80%,transparent 100%);animation:heroFadeIn 1.2s var(--ease-structural) both}
 @keyframes heroFadeIn{from{opacity:0;transform:translateY(24px)}to{opacity:1;transform:translateY(0)}}
 
-.hero-focus{position:relative;display:block;max-width:100%;margin:14px 0 0;padding:22px 26px 24px;border-radius:20px;border:1px solid rgba(255,255,255,0.12);
-background:linear-gradient(160deg,rgba(16,16,24,0.7),rgba(12,12,18,0.65));box-shadow:0 32px 80px rgba(0,0,0,0.45),inset 0 1px 0 rgba(255,255,255,0.1),0 0 80px rgba(172,25,183,0.06);
-backdrop-filter:blur(24px);-webkit-backdrop-filter:blur(24px);isolation:isolate}
-.hero-focus::before{content:'';position:absolute;inset:-60px -40px -120px;pointer-events:none;z-index:0;opacity:0.5;filter:blur(40px);background:
-radial-gradient(380px 220px at 50% 85%,rgba(172,25,183,0.14),transparent 65%)}
-.hero-focus::after{content:'';position:absolute;inset:10px;pointer-events:none;z-index:2;border:1px solid rgba(255,255,255,0.08);border-radius:14px}
-.hero-focus .sub-text{position:relative;z-index:3;font-size:16px;line-height:1.7;max-width:100%;margin-left:auto;margin-right:auto}
-.hero .cta-btn{min-width:240px}
+.hero-focus{position:relative;display:block;max-width:700px;margin:24px auto 0;padding:28px 34px 30px;border-radius:24px;border:1px solid rgba(255,255,255,0.12);text-align:center;
+background:linear-gradient(160deg,rgba(16,16,24,0.7),rgba(12,12,18,0.65));box-shadow:0 40px 100px rgba(0,0,0,0.5),inset 0 1px 0 rgba(255,255,255,0.1),0 0 90px rgba(172,25,183,0.06);
+backdrop-filter:blur(26px);-webkit-backdrop-filter:blur(26px);isolation:isolate}
+.hero-focus::before{content:'';position:absolute;inset:-80px -50px -150px;pointer-events:none;z-index:0;opacity:0.55;filter:blur(46px);background:
+radial-gradient(440px 250px at 50% 85%,rgba(172,25,183,0.13),transparent 65%)}
+.hero-focus::after{content:'';position:absolute;inset:11px;pointer-events:none;z-index:2;border:1px solid rgba(255,255,255,0.09);border-radius:18px}
+.hero-focus .sub-text{position:relative;z-index:3;font-size:17px;line-height:1.75;max-width:100%;margin-left:auto;margin-right:auto;text-align:center}
+.hero .cta-btn{min-width:260px}
 
 /* ===== VSL ===== */
 .vsl-section{background:#050508;text-align:center;padding:var(--section-pad) 24px}
@@ -620,18 +619,16 @@ section + .glow-divider{margin-top:0;margin-bottom:0}
 /* ===== RESPONSIVE — TABLET ONLY (481px – 768px) ===== */
 @media(min-width:481px) and (max-width:768px){
 .navbar-logo img{height:48px}
-/* Hero — collapse to single column */
-.hero{padding-top:96px;padding-bottom:32px;min-height:auto;overflow:hidden}
-.hero-inner{grid-template-columns:1fr;gap:24px;text-align:center}
-.hero-content{text-align:center}
-.hero-headline .hero-line1,.hero-headline .hero-line2{font-size:clamp(26px,5vw,38px)}
+/* Hero — tablet (centered, image still under text) */
+.hero{padding-top:104px;padding-bottom:0;min-height:auto;overflow:hidden}
+.hero-headline .hero-line1,.hero-headline .hero-line2{font-size:clamp(26px,5vw,40px)}
 .hero-headline .hero-line3{font-size:clamp(17px,3.2vw,22px)}
-.hero-focus{padding:20px 18px 22px;max-width:100%;margin:14px auto 0;overflow:hidden}
-.hero-focus .sub-text{font-size:15.5px}
+.hero-focus{padding:24px 22px 26px;max-width:600px;margin:18px auto 0;overflow:hidden}
+.hero-focus .sub-text{font-size:16px}
 .hero .cta-btn{min-width:0;width:100%;max-width:380px}
-.hero-figure{order:-1}
-.hero-figure img{min-width:auto;max-width:240px}
-.hero-figure-glow{width:380px;height:420px;filter:blur(80px)}
+.hero-figure{margin-top:48px}
+.hero-figure img{min-width:auto;max-width:280px}
+.hero-figure-glow{width:480px;height:520px;filter:blur(100px)}
 /* Timeline stays single column on tablet */
 .steps-timeline{max-width:100%}
 .process-grid{grid-template-columns:repeat(2,1fr)}
@@ -663,19 +660,17 @@ section + .glow-divider{margin-top:0;margin-bottom:0}
 .nav-links .nav-cta{width:100%;text-align:center;margin-top:8px}
 section{padding:60px 20px}
 .tech-section{padding:48px 20px}
-.hero{padding-top:90px;padding-bottom:24px;min-height:auto;overflow:hidden}
-.hero-inner{grid-template-columns:1fr;gap:20px;text-align:center}
-.hero-content{text-align:center}
-.hero-figure{order:-1}
-.hero-figure img{min-width:auto;max-width:220px;-webkit-mask-image:linear-gradient(to bottom,#000 55%,rgba(0,0,0,0.6) 78%,rgba(0,0,0,0.2) 92%,transparent 100%);mask-image:linear-gradient(to bottom,#000 55%,rgba(0,0,0,0.6) 78%,rgba(0,0,0,0.2) 92%,transparent 100%)}
-.hero-figure-glow{width:min(340px,88vw);height:380px;filter:blur(80px);max-width:100vw}
-.hero-headline .hero-line1{font-size:clamp(24px,6.5vw,36px)}
-.hero-headline .hero-line2{font-size:clamp(24px,6.5vw,36px)}
+.hero{padding-top:96px;padding-bottom:0;min-height:auto;overflow:hidden}
+.hero-figure{margin-top:40px}
+.hero-figure img{min-width:auto;max-width:240px;-webkit-mask-image:linear-gradient(to bottom,#000 45%,rgba(0,0,0,0.5) 65%,rgba(0,0,0,0.15) 85%,transparent 100%);mask-image:linear-gradient(to bottom,#000 45%,rgba(0,0,0,0.5) 65%,rgba(0,0,0,0.15) 85%,transparent 100%)}
+.hero-figure-glow{width:min(380px,90vw);height:420px;filter:blur(90px);max-width:100vw}
+.hero-headline .hero-line1{font-size:clamp(24px,6.8vw,38px)}
+.hero-headline .hero-line2{font-size:clamp(24px,6.8vw,38px)}
 .hero-headline .hero-line3{font-size:clamp(16px,4vw,20px);margin-top:8px}
-.hero-focus{padding:18px 16px 20px;border-radius:18px;max-width:100%;margin:14px auto 0;overflow:hidden}
-.hero-focus::before{inset:-40px -10px -80px;filter:blur(28px)}
-.hero-focus::after{inset:8px;border-radius:12px}
-.hero-focus .sub-text{font-size:15px;line-height:1.65}
+.hero-focus{padding:20px 18px 22px;border-radius:20px;max-width:100%;margin:18px auto 0;overflow:hidden}
+.hero-focus::before{inset:-50px -10px -90px;filter:blur(30px)}
+.hero-focus::after{inset:9px;border-radius:14px}
+.hero-focus .sub-text{font-size:15.5px;line-height:1.7}
 .hero .cta-btn{min-width:0;width:100%;max-width:360px}
 .sub-text{margin:0 auto}
 .steps-timeline{max-width:100%}
@@ -778,16 +773,17 @@ body{padding-bottom:70px}
 @media(max-width:480px){
 section{padding:48px 14px}
 .tech-section{padding:40px 14px}
-.hero{padding-top:74px;padding-bottom:20px}
-.hero-headline .hero-line1,.hero-headline .hero-line2{font-size:clamp(22px,7.5vw,32px);letter-spacing:-0.4px}
+.hero{padding-top:80px;padding-bottom:0}
+.hero-headline .hero-line1,.hero-headline .hero-line2{font-size:clamp(22px,7.8vw,32px);letter-spacing:-0.4px}
 .hero-headline .hero-line3{font-size:clamp(15px,4.4vw,18px);margin-top:8px;letter-spacing:-0.2px}
-.hero-focus{padding:16px 14px 18px;border-radius:16px;margin:12px auto 0;overflow:hidden}
-.hero-focus::before{inset:-20px -5px -40px;filter:blur(22px)}
-.hero-focus .sub-text{font-size:14.5px;line-height:1.6}
-.hero-figure img{min-width:auto;max-width:200px;-webkit-mask-image:linear-gradient(to bottom,#000 60%,rgba(0,0,0,0.6) 80%,rgba(0,0,0,0.2) 92%,transparent 100%);mask-image:linear-gradient(to bottom,#000 60%,rgba(0,0,0,0.6) 80%,rgba(0,0,0,0.2) 92%,transparent 100%)}
-.hero-figure-glow{width:min(320px,86vw);height:360px;max-width:100vw;background:radial-gradient(ellipse 75% 65% at 50% 50%,rgba(172,25,183,0.36),rgba(154,0,165,0.16) 50%,transparent 80%)}
+.hero-focus{padding:18px 14px 20px;border-radius:16px;margin:14px auto 0;overflow:hidden}
+.hero-focus::before{inset:-30px -5px -50px;filter:blur(24px)}
+.hero-focus .sub-text{font-size:14.5px;line-height:1.65}
+.hero-figure{margin-top:32px;margin-bottom:-30px}
+.hero-figure img{min-width:auto;max-width:220px;-webkit-mask-image:linear-gradient(to bottom,#000 50%,rgba(0,0,0,0.6) 75%,rgba(0,0,0,0.2) 90%,transparent 100%);mask-image:linear-gradient(to bottom,#000 50%,rgba(0,0,0,0.6) 75%,rgba(0,0,0,0.2) 90%,transparent 100%)}
+.hero-figure-glow{width:min(360px,90vw);height:400px;max-width:100vw;background:radial-gradient(ellipse 75% 65% at 50% 50%,rgba(172,25,183,0.36),rgba(154,0,165,0.16) 50%,transparent 80%)}
 .hero .cta-btn{width:100%;max-width:100%}
-.hero-cta-area{margin-top:20px}
+.hero-cta-area{margin-top:24px}
 /* Single column everywhere */
 .system-items .system-item{flex:0 0 86%;padding:16px 14px;grid-template-columns:42px 1fr;gap:0 12px}
 .system-items--2 .system-item{flex:0 0 90%}


### PR DESCRIPTION
User feedback: the side-by-side grid hero felt like a generic sales page. Restoring the original centered, strategic-opening feel.

CSS-only structural revert. No HTML changes (hero-content already precedes hero-figure inside hero-inner — image now flows below the text, not beside it).

Desktop hero (192-223):
- .hero: min-height:100vh restored, padding-top:110px, padding-bottom:0, text-align:center, overflow:hidden
- .hero-inner: removed grid; flex-direction:column, align-items:center, max-width:900px, gap:0
- .hero-content: text-align:center, max-width:900px, margin:0 auto
- .hero-headline: text-align:center, margin auto
- .hero-focus: max-width:700px, margin:24px auto 0, text-align:center, padding 28px 34px 30px (back to original premium feel)
- .hero-focus .sub-text: font-size 17px, text-align:center
- .hero-cta-area: text-align:center, margin-top 28px
- .hero-figure: order:2, margin-top:64px, justify-content:center, width:100% (sits below content)
- .hero-figure img: max-width:420px (back to original)
- .hero-figure-glow: 720x720 (restored, blur:130px)
- .hero .cta-btn: min-width:260px

Tablet (481-768):
- Removed grid-template-columns:1fr override (no longer needed)
- Removed text-align:center duplicates (inherited from base)
- .hero-figure margin-top:48px, max-width:280px

Mobile (≤768):
- Removed grid-template-columns:1fr override
- Removed order:-1 (image stays below text now)
- .hero-figure margin-top:40px, max-width:240px

Small mobile (≤480):
- .hero-figure margin-top:32px, max-width:220px

Untouched: copy, forms, IDs, function names, GTM, Meta Pixel, Consent Mode, WEBHOOK_URL, dataLayer, all tracking infrastructure. QA verified intact (GTM=4, Pixel=8, Consent=11, dataLayer=12, 17 sections, 14 booklets, noback.png in hero, 0 forbidden phrases). https://claude.ai/code/session_012PyS9bowC2QvF1UZqeF98G